### PR TITLE
Adding ADIOS type to tests

### DIFF
--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -294,6 +294,10 @@ CONTAINS
       ! pnetcdf
       num_iotypes = num_iotypes + 1
 #endif
+#ifdef _ADIOS
+      ! adios
+      num_iotypes = num_iotypes + 1
+#endif
 
     ! ALLOCATE with 0 elements ok?
     ALLOCATE(iotypes(num_iotypes))
@@ -304,6 +308,12 @@ CONTAINS
       ! pnetcdf
       iotypes(i) = PIO_iotype_pnetcdf
       iotype_descs(i) = "PNETCDF"
+      i = i + 1
+#endif
+#ifdef _ADIOS
+      ! adios
+      iotypes(i) = PIO_iotype_adios
+      iotype_descs(i) = "ADIOS"
       i = i + 1
 #endif
 #ifdef _NETCDF4
@@ -355,6 +365,10 @@ CONTAINS
       ! pnetcdf
       num_iotypes = num_iotypes + 1
 #endif
+#ifndef _ADIOS
+      ! adios
+      num_iotypes = num_iotypes + 1
+#endif
 
     ! ALLOCATE with 0 elements ok?
     ALLOCATE(iotypes(num_iotypes))
@@ -365,6 +379,12 @@ CONTAINS
       ! pnetcdf
       iotypes(i) = PIO_iotype_pnetcdf
       iotype_descs(i) = "PNETCDF"
+      i = i + 1
+#endif
+#ifndef _ADIOS
+      ! adios
+      iotypes(i) = PIO_iotype_adios
+      iotype_descs(i) = "ADIOS"
       i = i + 1
 #endif
 #ifndef _NETCDF
@@ -411,6 +431,10 @@ CONTAINS
       ! pnetcdf
       num_iotypes = num_iotypes + 1
 #endif
+#ifdef _ADIOS
+      ! adios
+      num_iotypes = num_iotypes + 1
+#endif
 
     ! ALLOCATE with 0 elements ok?
     ALLOCATE(iotypes(num_iotypes))
@@ -421,6 +445,12 @@ CONTAINS
       ! pnetcdf
       iotypes(i) = PIO_iotype_pnetcdf
       iotype_descs(i) = "PNETCDF"
+      i = i + 1
+#endif
+#ifdef _ADIOS
+      ! adios
+      iotypes(i) = PIO_iotype_adios
+      iotype_descs(i) = "ADIOS"
       i = i + 1
 #endif
 #ifdef _NETCDF4
@@ -472,12 +502,22 @@ CONTAINS
       ! pnetcdf
       num_iotypes = num_iotypes + 1
 #endif
+#ifndef _ADIOS
+      ! adios
+      num_iotypes = num_iotypes + 1
+#endif
 
     ! ALLOCATE with 0 elements ok?
     ALLOCATE(iotypes(num_iotypes))
     ALLOCATE(iotype_descs(num_iotypes))
 
     i = 1
+#ifndef _ADIOS
+      ! adios
+      iotypes(i) = PIO_iotype_adios
+      iotype_descs(i) = "ADIOS"
+      i = i + 1
+#endif
 #ifndef _NETCDF
       ! netcdf
       iotypes(i) = PIO_iotype_netcdf


### PR DESCRIPTION
Adding the ADIOS file type to the fortran testing framework.

All fortran tests now also test the PIO_iotype_adios file type.

Fixes #2 