### PR TITLE
Applying some patches to adios_support branch

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -530,6 +530,7 @@ typedef struct wmulti_buffer
     struct wmulti_buffer *next;
 } wmulti_buffer;
 
+#ifdef _ADIOS
 /** Variable definition information saved at pioc_def_var,
  * so that ADIOS can define the variable at write time when
  * local dimensions and offsets are known.
@@ -547,6 +548,8 @@ typedef struct adios_var_desc_t
     /** Global dims (dim var ids) */
     int * gdimids;
 } adios_var_desc_t;
+#endif
+
 /**
  * File descriptor structure.
  *

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -862,7 +862,48 @@ int pio_read_darray_nc(file_desc_t *file, io_desc_t *iodesc, int vid, void *iobu
             {
 #ifdef _NETCDF4
             case PIO_IOTYPE_NETCDF4P:
-                ierr = nc_get_vara(file->fh, vid, start, count, bufptr);
+                /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+                switch (iodesc->piotype)
+                {
+                case PIO_BYTE:
+                    ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+                    break;
+                case PIO_CHAR:
+                    ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+                    break;
+                case PIO_SHORT:
+                    ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+                    break;
+                case PIO_INT:
+                    ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+                    break;
+                case PIO_FLOAT:
+                    ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+                    break;
+                case PIO_DOUBLE:
+                    ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+                    break;
+                case PIO_UBYTE:
+                    ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+                    break;
+                case PIO_USHORT:
+                    ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+                    break;
+                case PIO_UINT:
+                    ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+                    break;
+                case PIO_INT64:
+                    ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+                    break;
+                case PIO_UINT64:
+                    ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+                    break;
+                case PIO_STRING:
+                    ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+                    break;
+                default:
+                    return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+                }
                 break;
 #endif
 #ifdef _PNETCDF
@@ -1149,7 +1190,50 @@ int pio_read_darray_nc_serial(file_desc_t *file, io_desc_t *iodesc, int vid,
                     loffset += regionsize;
 
                     /* Read the data. */
-                    ierr = nc_get_vara(file->fh, vid, start, count, bufptr);
+                    /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */
+                    switch (iodesc->piotype)
+                    {
+                    case PIO_BYTE:
+                        ierr = nc_get_vara_schar(file->fh, vid, start, count, (signed char*)bufptr);
+                        break;
+                    case PIO_CHAR:
+                        ierr = nc_get_vara_text(file->fh, vid, start, count, (char*)bufptr);
+                        break;
+                    case PIO_SHORT:
+                        ierr = nc_get_vara_short(file->fh, vid, start, count, (short*)bufptr);
+                        break;
+                    case PIO_INT:
+                        ierr = nc_get_vara_int(file->fh, vid, start, count, (int*)bufptr);
+                        break;
+                    case PIO_FLOAT:
+                        ierr = nc_get_vara_float(file->fh, vid, start, count, (float*)bufptr);
+                        break;
+                    case PIO_DOUBLE:
+                        ierr = nc_get_vara_double(file->fh, vid, start, count, (double*)bufptr);
+                        break;
+#ifdef _NETCDF4
+                    case PIO_UBYTE:
+                        ierr = nc_get_vara_uchar(file->fh, vid, start, count, (unsigned char*)bufptr);
+                        break;
+                    case PIO_USHORT:
+                        ierr = nc_get_vara_ushort(file->fh, vid, start, count, (unsigned short*)bufptr);
+                        break;
+                    case PIO_UINT:
+                        ierr = nc_get_vara_uint(file->fh, vid, start, count, (unsigned int*)bufptr);
+                        break;
+                    case PIO_INT64:
+                        ierr = nc_get_vara_longlong(file->fh, vid, start, count, (long long*)bufptr);
+                        break;
+                    case PIO_UINT64:
+                        ierr = nc_get_vara_ulonglong(file->fh, vid, start, count, (unsigned long long*)bufptr);
+                        break;
+                    case PIO_STRING:
+                        ierr = nc_get_vara_string(file->fh, vid, start, count, (char**)bufptr);
+                        break;
+#endif /* _NETCDF4 */
+                    default:
+                        return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__);
+                    }
 
                     /* Check error code of netCDF call. */
                     if (ierr)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -76,9 +76,11 @@ int PIOc_strerror(int pioerr, char *errmsg)
         case PIO_EBADIOTYPE:
             strcpy(errmsg, "Bad IO type");
             break;
+#ifdef _ADIOS
         case PIO_EADIOSREAD:
              strcpy(errmsg, "ADIOS IO type does not support read operations");
              break;
+#endif
         default:
             strcpy(errmsg, "Unknown Error: Unrecognized error code");
         }

--- a/tests/general/ncdf_simple_tests.F90.in
+++ b/tests/general/ncdf_simple_tests.F90.in
@@ -99,6 +99,68 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_def_var
 
 PIO_TF_AUTO_TEST_SUB_END test_def_var
 
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_data_conversion
+  use ncdf_simple_tests_tgv
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: data_fname = "pio_test_data_conversion.nc"
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
+  integer, dimension(VEC_LOCAL_SZ) :: wbuf
+  PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: rbuf, exp_val
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  compdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+  wbuf = pio_tf_world_rank_;
+  exp_val = pio_tf_world_rank_;
+
+  ! Set the decomposition for writing data as PIO_int
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, wiodesc)
+
+  ! Set the decomposition for reading data as various types 
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, riodesc)
+
+  ierr = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, data_fname, PIO_CLOBBER) 
+  PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(data_fname))
+
+  ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+  PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(data_fname))
+
+  ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_int, (/pio_dim/), pio_var)
+  PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(data_fname))
+
+  ierr = PIO_enddef(pio_file)
+  PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(data_fname))
+
+  ! Write the variable out
+  call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr)
+  PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(data_fname))
+
+  call PIO_syncfile(pio_file)
+
+  ! Read the variable back (data conversion might occur)
+  call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+  PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(data_fname))
+
+  PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+  call PIO_closefile(pio_file)
+  call PIO_deletefile(pio_tf_iosystem_, data_fname);
+
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+
+PIO_TF_AUTO_TEST_SUB_END test_data_conversion
+
 PIO_TF_TEST_DRIVER_BEGIN
   use ncdf_simple_tests_tgv
   Implicit none


### PR DESCRIPTION
1) Fixed some build errors (when WITH_ADIOS option is OFF)
2) Imported a patch from acme_develop branch with a new unit test. This patch is required for ACME test ERS.f09_g16.I1850CLM45CN to pass (use ACME branch dqwu/test_pio2, which fixed some bugs on ACME side)

Note:
Latest PIO2 master branch is unstable (new issues might be introduced). The goal is to make adios_support branch as stable as acme_develop branch: most (if not all) ACME (or ESMCI/cime) tests/cases should pass with adios_support branch (at least when WITH_ADIOS option is OFF).