### PR TITLE
Reset 64bit offset and data flags for NetCDF4

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1783,6 +1783,28 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* If this task is in the IO component, do the IO. */
     if (ios->ioproc)
     {
+#ifdef _NETCDF4
+        /* All NetCDF4 files use the CDF5 file format by default,
+         * - 64bit offset, 64bit data
+         * However the NetCDF library does not allow setting the 
+         * NC_64BIT_OFFSET or NC_64BIT_DATA flags for NetCDF4 types 
+         * - this internal reset of flags is for user convenience */
+        if ((file->iotype == PIO_IOTYPE_NETCDF4P) ||
+            (file->iotype == PIO_IOTYPE_NETCDF4C))
+        {
+            LOG((2, "File create mode (before change) = %x",file->mode));
+            if ((file->mode & NC_64BIT_OFFSET) == NC_64BIT_OFFSET)
+            {
+                file->mode &= ~NC_64BIT_OFFSET;
+            }
+            if ((file->mode & NC_64BIT_DATA) == NC_64BIT_DATA)
+            {
+                file->mode &= ~NC_64BIT_DATA;
+            }
+            LOG((2, "File create mode (after change) = %x",file->mode));
+        }
+#endif
+
         switch (file->iotype)
         {
 #ifdef _NETCDF4

--- a/tests/general/ncdf_simple_tests.F90.in
+++ b/tests/general/ncdf_simple_tests.F90.in
@@ -5,6 +5,32 @@ MODULE ncdf_simple_tests_tgv
   integer :: tgv_iotype
 END MODULE ncdf_simple_tests_tgv
 
+PIO_TF_AUTO_TEST_SUB_BEGIN test_create
+  use ncdf_simple_tests_tgv
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: fname = "pio_test_create.nc"
+  integer, parameter :: MAX_FLAGS = 3
+  integer :: flags(MAX_FLAGS) = (/PIO_CLOBBER,&
+                                  IOR(PIO_CLOBBER,PIO_64BIT_OFFSET),&
+                                  IOR(PIO_CLOBBER,PIO_64BIT_DATA)&
+                                  /)
+  integer :: i
+  integer :: ret
+  
+  do i=1,MAX_FLAGS
+    PIO_TF_LOG(0,*) "Trying to create a file: type = ", tgv_iotype, ": flags = ", flags(i)
+
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, fname, flags(i))
+    PIO_TF_CHECK_ERR(ret, "Failed to create:" // trim(fname))
+
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, fname)
+  end do
+
+PIO_TF_AUTO_TEST_SUB_END test_create
+
 PIO_TF_AUTO_TEST_SUB_BEGIN test_clobber
   use ncdf_simple_tests_tgv
   Implicit none


### PR DESCRIPTION
When creating NetCDF4 files the NetCDF library does not allow
NC_64BIT_OFFSET and NC_64BIT_DATA flags. However these flags are
required to create CDF2 and CDF5 files respectively for NetCDF
classic format. Since these flags are passed (via PIO flags) to 
PIO it is convenient for the user to be able to use the same 
flags for all iotypes.
