### PR TITLE
Adding tests with multiple contiguous regions

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -220,9 +220,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
      * and write (or read). The buffer size on io task 0 must be as
      * large as the largest used to accommodate this serial io
      * method.  */
-    rlen = 0;
-    if (iodesc->llen > 0)
-        rlen = iodesc->maxiobuflen * nvars;
+    rlen = iodesc->maxiobuflen * nvars;
 
     /* Allocate iobuf. */
     if (rlen > 0)

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(GENERATED_SRCS pio_file_simple_tests.F90
   pio_decomp_tests_3d.F90
   pio_decomp_frame_tests.F90
   pio_decomp_fillval.F90
+  pio_decomp_fillval2.F90
   pio_iosystem_tests.F90
   pio_iosystem_tests2.F90
   pio_iosystem_tests3.F90)
@@ -791,6 +792,25 @@ if (PIO_USE_MPISERIAL)
 else ()
   add_mpi_test(pio_decomp_fillval
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_decomp_fillval
+    NUMPROCS 4
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+endif ()
+
+#===== pio_decomp_fillval2 =====
+add_executable (pio_decomp_fillval2 EXCLUDE_FROM_ALL
+  pio_decomp_fillval2.F90
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
+target_link_libraries (pio_decomp_fillval2 piof)
+add_dependencies (tests pio_decomp_fillval2)
+
+if (PIO_USE_MPISERIAL)
+  add_test(NAME pio_decomp_fillval2
+    COMMAND pio_decomp_fillval2)
+  set_tests_properties(pio_decomp_fillval2
+    PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+else ()
+  add_mpi_test(pio_decomp_fillval2
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_decomp_fillval2
     NUMPROCS 4
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(GENERATED_SRCS pio_file_simple_tests.F90
   pio_decomp_tests_1d.F90
   pio_decomp_tests_2d.F90
   pio_decomp_tests_3d.F90
+  pio_sync_tests.F90
   pio_decomp_frame_tests.F90
   pio_decomp_fillval.F90
   pio_decomp_fillval2.F90
@@ -754,6 +755,25 @@ else ()
   add_mpi_test(pio_decomp_tests_3d_4p_2iop_1agg
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_decomp_tests_3d
     ARGUMENTS --pio-tf-num-io-tasks=2 --pio-tf-num-aggregators=1
+    NUMPROCS 4
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+endif ()
+
+#===== pio_sync_tests =====
+add_executable (pio_sync_tests EXCLUDE_FROM_ALL
+  pio_sync_tests.F90
+  ${CMAKE_CURRENT_SOURCE_DIR}/util/pio_tutil.F90)
+target_link_libraries (pio_sync_tests piof)
+add_dependencies (tests pio_sync_tests)
+
+if (PIO_USE_MPISERIAL)
+  add_test(NAME pio_sync_tests
+    COMMAND pio_sync_tests)
+  set_tests_properties(pio_sync_tests
+    PROPERTIES TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+else ()
+  add_mpi_test(pio_sync_tests
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_sync_tests
     NUMPROCS 4
     TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 endif ()

--- a/tests/general/pio_decomp_fillval2.F90.in
+++ b/tests/general/pio_decomp_fillval2.F90.in
@@ -259,3 +259,105 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
   deallocate(wbuf)
 
 PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_mreg_imp_fval
+
+! A test that writes out val with only one data point/value
+! All procs, except the last proc, only writes out fillvalues
+! the last proc, writes out 1 value that is not a fillvalue and
+! the rest all fillvalues.
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_one_val
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
+  ! Compdof value to suggest that data point is a hole, this hole
+  ! is usually filled with a fillvalue
+  integer, parameter :: PIO_COMPDOF_FILLVAL = 0
+  PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: wbuf, rbuf, exp_val
+  ! The buffer fillvalue to be used when writing data
+  PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  logical :: is_last_proc = .false.
+
+  if(pio_tf_world_rank_ == pio_tf_world_sz_ - 1) then
+    is_last_proc = .true.
+  end if
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  rcompdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+  wcompdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+
+  wbuf = wcompdof
+  exp_val = wcompdof
+  rbuf = 0
+
+  ! All indices have fillvalues by default
+  do i=1,VEC_LOCAL_SZ
+    wcompdof(i) = PIO_COMPDOF_FILLVAL
+    exp_val(i) = BUF_FILLVAL
+  end do
+
+  ! Only the last proc has a valid data value
+  if(is_last_proc) then
+    wcompdof(VEC_LOCAL_SZ) = VEC_LOCAL_SZ * pio_tf_world_rank_ + VEC_LOCAL_SZ
+    exp_val(VEC_LOCAL_SZ) = wcompdof(VEC_LOCAL_SZ)
+  end if 
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, wcompdof, wiodesc)
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, rcompdof, riodesc)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+
+    write(filename,'(a,i1)') "test_pio_decomp_fillval_tests.testfile",i
+
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename)
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_one_val
+

--- a/tests/general/pio_decomp_fillval2.F90.in
+++ b/tests/general/pio_decomp_fillval2.F90.in
@@ -3,7 +3,7 @@
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
   implicit none
-  type(var_desc_t)  :: pio_var
+  type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
   type(io_desc_t) :: wiodesc, riodesc
@@ -74,19 +74,34 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+                        (/pio_dim/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE,&
+                        (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
     ! Write the variable out
-    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    call PIO_write_darray(pio_file, pio_var1, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
     call PIO_syncfile(pio_file)
 
-    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
 
     PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
@@ -113,7 +128,7 @@ PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_mreg_exp_fval
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
   implicit none
-  type(var_desc_t)  :: pio_var
+  type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
   type(io_desc_t) :: wiodesc, riodesc
@@ -196,19 +211,34 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+                        (/pio_dim/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE,&
+                        (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
     ! Write the variable out
-    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    call PIO_write_darray(pio_file, pio_var1, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
     call PIO_syncfile(pio_file)
 
-    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
 
     PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")

--- a/tests/general/pio_decomp_fillval2.F90.in
+++ b/tests/general/pio_decomp_fillval2.F90.in
@@ -1,0 +1,231 @@
+! nc write 1d array with fillvalues (the holes are explicitly specified)
+! Each process writes out data with "rank + 1" holes, strided by 2
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
+  implicit none
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(:), allocatable :: wcompdof, rcompdof, compdof_rel_disps
+  ! Compdof value to suggest that data point is a hole, this hole
+  ! is usually filled with a fillvalue
+  integer, parameter :: PIO_COMPDOF_FILLVAL = 0
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: wbuf, rbuf, exp_val
+  ! The buffer fillvalue to be used when writing data
+  PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, j, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Stride for holes in data
+  integer, parameter :: HSTRIDE = 2
+  integer :: num_local_holes, vec_local_sz
+
+  num_local_holes = pio_tf_world_rank_ + 1
+  vec_local_sz = pio_tf_world_sz_ * HSTRIDE
+
+  allocate(wcompdof(vec_local_sz))
+  allocate(rcompdof(vec_local_sz))
+  allocate(compdof_rel_disps(vec_local_sz))
+  do i=1,vec_local_sz
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = vec_local_sz * pio_tf_world_sz_
+  rcompdof = vec_local_sz * pio_tf_world_rank_ + compdof_rel_disps
+  wcompdof = vec_local_sz * pio_tf_world_rank_ + compdof_rel_disps
+
+  allocate(wbuf(vec_local_sz))
+  allocate(rbuf(vec_local_sz))
+  allocate(exp_val(vec_local_sz))
+  wbuf = wcompdof
+  exp_val = wcompdof
+  rbuf = 0
+
+  ! For hole indices we expect (BUF_FILLVAL == -2)
+  ! holes are strided by HSTRIDE
+  do i=1,num_local_holes
+    j = (i - 1) * HSTRIDE + 1
+    wcompdof(j) = PIO_COMPDOF_FILLVAL
+    exp_val(j) = BUF_FILLVAL
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, wcompdof, wiodesc)
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, rcompdof, riodesc)
+
+  deallocate(compdof_rel_disps)
+  deallocate(rcompdof)
+  deallocate(wcompdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+
+    write(filename,'(a,i1)') "test_pio_decomp_fillval_tests.testfile",i
+
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename)
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_mreg_exp_fval
+
+! nc write 1d array with fillvalues (the holes are implicitly specified)
+! Each process writes out data with "rank + 1" holes, strided by 2
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
+  implicit none
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(:), allocatable :: wcompdof, rcompdof
+  integer, dimension(:), allocatable :: rcompdof_rel_disps
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: wbuf, rbuf, exp_val
+  ! The buffer fillvalue to be used when writing data
+  PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, j, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Stride for holes in data
+  integer, parameter :: HSTRIDE = 2
+  integer :: num_local_holes, vec_local_rsz, vec_local_wsz
+
+  ! Data written out by each process has "rank + 1" holes
+  num_local_holes = pio_tf_world_rank_ + 1
+  vec_local_rsz = pio_tf_world_sz_ * HSTRIDE
+  vec_local_wsz = vec_local_rsz - num_local_holes
+
+  allocate(wcompdof(vec_local_wsz))
+  allocate(rcompdof(vec_local_rsz))
+  allocate(rcompdof_rel_disps(vec_local_rsz))
+  do i=1,vec_local_rsz
+    rcompdof_rel_disps(i) = i
+  end do
+  dims(1) = vec_local_rsz * pio_tf_world_sz_
+
+  ! We read more than we write (for procs with holes)
+  rcompdof = vec_local_rsz * pio_tf_world_rank_ + rcompdof_rel_disps
+
+  ! Since holes are implicit - only specifying valid write compdofs
+  ! holes are strided by HSTRIDE
+  j = 1
+  do i=1,num_local_holes
+    wcompdof(j) = vec_local_rsz * pio_tf_world_rank_ + i * HSTRIDE
+    j = j + 1
+  end do
+  do i=num_local_holes*HSTRIDE+1,vec_local_rsz
+    wcompdof(j) = vec_local_rsz * pio_tf_world_rank_ + i
+    j = j + 1
+  end do
+
+  allocate(wbuf(vec_local_wsz))
+  allocate(rbuf(vec_local_rsz))
+  allocate(exp_val(vec_local_rsz))
+  wbuf = wcompdof
+  exp_val = rcompdof
+  rbuf = 0
+
+  ! For hole indices we expect (BUF_FILLVAL == -2)
+  ! holes are strided by HSTRIDE
+  do i=1,num_local_holes
+    j = (i - 1) * HSTRIDE + 1
+    exp_val(j) = BUF_FILLVAL
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, wcompdof, wiodesc)
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, rcompdof, riodesc)
+
+  deallocate(rcompdof_rel_disps)
+  deallocate(rcompdof)
+  deallocate(wcompdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+
+    write(filename,'(a,i1)') "test_pio_decomp_fillval_tests.testfile",i
+
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename)
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_mreg_imp_fval

--- a/tests/general/pio_decomp_fillval2.F90.in
+++ b/tests/general/pio_decomp_fillval2.F90.in
@@ -361,3 +361,97 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_one_val
   call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_one_val
 
+! A test where all odd procs write only fillvalues
+! - even procs write non-fillvalues
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_odd_fval
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
+  ! Compdof value to suggest that data point is a hole, this hole
+  ! is usually filled with a fillvalue
+  integer, parameter :: PIO_COMPDOF_FILLVAL = 0
+  PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: wbuf, rbuf, exp_val
+  ! The buffer fillvalue to be used when writing data
+  PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  logical :: is_odd_proc = .false.
+
+  if(mod(pio_tf_world_rank_, 2) /= 0) then
+    is_odd_proc = .true.
+  end if
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  rcompdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+  wcompdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+
+  wbuf = wcompdof
+  exp_val = wcompdof
+  rbuf = 0
+
+  ! All odd procs write only fillvalues
+  if(is_odd_proc) then
+    do i=1,VEC_LOCAL_SZ
+      wcompdof(i) = PIO_COMPDOF_FILLVAL
+      exp_val(i) = BUF_FILLVAL
+    end do
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, wcompdof, wiodesc)
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, rcompdof, riodesc)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+
+    write(filename,'(a,i1)') "test_pio_decomp_fillval_tests.testfile",i
+
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename)
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_1d_odd_fval

--- a/tests/general/pio_decomp_tests_1d.F90.in
+++ b/tests/general/pio_decomp_tests_1d.F90.in
@@ -66,6 +66,34 @@ SUBROUTINE get_1d_bc_info(rank, sz, dims, start, count, force_rearrange)
 
 END SUBROUTINE
 
+! Get a block cyclic decomposition with multiple regions to write
+! from a single proc
+! # All procs have VEC_LOCAL_SZ elements starting at offset rank+1
+!   and also starting at offset (size * VEC_LOCAL_SZ)
+! e.g. For VEC_LOCAL_SZ = 2, NUM_REGIONS=2
+! e.g. 1)    [1,2,7,8] [3,4,9,10] [5,6,11,12]
+SUBROUTINE get_1d_bc_mreg_info(rank, sz, dims, start, count)
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer, parameter :: NUM_REGIONS = 3
+  integer, intent(in) :: rank
+  integer, intent(in) :: sz
+  integer, dimension(1), intent(out) :: dims
+  integer, dimension(:), allocatable, intent(out) :: start
+  integer, dimension(:), allocatable, intent(out) :: count
+  integer :: i
+
+  dims(1) = sz * VEC_LOCAL_SZ * NUM_REGIONS
+  allocate(start(NUM_REGIONS))
+  allocate(count(NUM_REGIONS))
+
+  
+  do i=1,NUM_REGIONS
+    count(i) = VEC_LOCAL_SZ
+    start(i) = rank * VEC_LOCAL_SZ + (i-1) * (sz * VEC_LOCAL_SZ) + 1
+  end do
+
+END SUBROUTINE get_1d_bc_mreg_info
+
 ! Get a 1d block decomposition with holes
 ! If has_hole is TRUE, the decomposition is such that
 ! # All even procs have VEC_LOCAL_SZ * 2 elements
@@ -227,6 +255,107 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
     end do !wr_rearr_opt_idx=1,size(enable_wr_rearr)
   end do !rd_rearr_opt_idx=1,size(enable_rd_rearr)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_rd_1d_bc
+
+! Test write/read of a variable where each proc writes/reads multiple regions
+! of the data
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_mreg_1d_bc
+  implicit none
+  interface
+    subroutine get_1d_bc_mreg_info(rank, sz, dims, start, count)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+    end subroutine get_1d_bc_mreg_info
+  end interface
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: start, count
+  integer :: total_count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, j, idx, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  call get_1d_bc_mreg_info(pio_tf_world_rank_, pio_tf_world_sz_,&
+         dims, start, count)
+  total_count = 0
+  do i=1,size(count)
+    total_count = total_count + count(i) 
+  end do
+  allocate(wbuf(total_count))
+  allocate(rbuf(total_count))
+  allocate(compdof(total_count))
+  do i=1,size(count)
+    do j=1,count(i)
+      idx = (i-1)*count(i) + j
+      compdof(idx) = start(i) + j - 1
+      wbuf(idx) = compdof(idx)
+      rbuf(idx) = compdof(idx)
+    end do
+  end do
+  if(allocated(start)) then
+    deallocate(start)
+  end if
+  if(allocated(count)) then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, iodesc)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out
+    call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc)
+  deallocate(rbuf)
+  deallocate(wbuf)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_rd_mreg_1d_bc
 
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes

--- a/tests/general/pio_sync_tests.F90.in
+++ b/tests/general/pio_sync_tests.F90.in
@@ -1,0 +1,410 @@
+! Get a block cyclic decomposition
+! If force_rearrange is FALSE, the decomposition is such that
+! # All even procs have VEC_LOCAL_SZ elements
+! # All odd procs have VEC_LOCAL_SZ + 1 elements
+! e.g. For VEC_LOCAL_SZ = 2,
+! e.g. 1)    [1,2] [3,4,5] [6,7]
+! e.g. 2)    [1,2] [3,4,5] [6,7] [8,9,10]
+! e.g. 3)    [1,2] [3,4,5] [6,7] [8,9,10] [11,12]
+! If force_rearrange is TRUE, the decomposition is such that,
+! If possible, the even rank "exchanges" elements with the next
+! higher ranked odd proc.
+! This for example can be used to force rearrangement when reading
+! or writing data.
+! e.g. For VEC_LOCAL_SZ = 2,
+! e.g. 1)    [3,4,5] [1,2] [6,7]
+! e.g. 2)    [3,4,5] [1,2] [8,9,10] [6,7]
+! e.g. 3)    [3,4,5] [1,2] [8,9,10] [6,7] [11,12]
+SUBROUTINE get_1d_bc_info(rank, sz, dims, start, count, force_rearrange)
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer, parameter :: NUM_REGIONS = 1
+  integer, intent(in) :: rank
+  integer, intent(in) :: sz
+  integer, dimension(1), intent(out) :: dims
+  integer, dimension(:), allocatable, intent(out) :: start
+  integer, dimension(:), allocatable, intent(out) :: count
+  logical, intent(in) :: force_rearrange
+
+  logical :: is_even_rank
+  integer :: num_odd_procs, num_even_procs
+  integer :: iodd, ieven
+
+  allocate(start(NUM_REGIONS))
+  allocate(count(NUM_REGIONS))
+
+  is_even_rank = .false.
+  if (mod(rank, 2) == 0) then
+    is_even_rank = .true.
+  end if
+  num_odd_procs = sz / 2
+  num_even_procs = sz - num_odd_procs
+  dims(1) = num_even_procs * VEC_LOCAL_SZ + num_odd_procs * (VEC_LOCAL_SZ + 1)
+  ! Number of odd and even procs before this rank
+  iodd = rank / 2
+  ieven = (rank + 1) / 2
+  if(force_rearrange) then
+    ! Make sure that we force rearrangement
+    if (is_even_rank) then
+      if(rank + 1 < sz) then
+        ! Force rearrangement
+        count(1) = VEC_LOCAL_SZ + 1
+        start(1) = ieven * VEC_LOCAL_SZ + iodd * (VEC_LOCAL_SZ + 1) + (VEC_LOCAL_SZ) + 1
+      else
+        count(1) = VEC_LOCAL_SZ
+        start(1) = ieven * VEC_LOCAL_SZ + iodd * (VEC_LOCAL_SZ + 1) + 1
+      end if
+    else
+      ! For all odd procs there is an even lower ranked, rank-1, proc
+      ! So force rearrangement
+      count(1) = VEC_LOCAL_SZ
+      start(1) = ieven * VEC_LOCAL_SZ + iodd * (VEC_LOCAL_SZ + 1) - (VEC_LOCAL_SZ) + 1
+    end if
+  else
+    if (is_even_rank) then
+      count(1) = VEC_LOCAL_SZ
+    else
+      count(1) = VEC_LOCAL_SZ + 1
+    end if
+    start(1) = ieven * VEC_LOCAL_SZ + iodd * (VEC_LOCAL_SZ + 1) + 1
+  end if
+
+END SUBROUTINE
+
+! Get a block cyclic decomposition with multiple regions to write
+! from a single proc
+! # All procs have VEC_LOCAL_SZ elements starting at offset rank+1
+!   and also starting at offset (size * VEC_LOCAL_SZ)
+! e.g. For VEC_LOCAL_SZ = 2, NUM_REGIONS=2
+! e.g. 1)    [1,2,7,8] [3,4,9,10] [5,6,11,12]
+SUBROUTINE get_1d_bc_mreg_info(rank, sz, dims, start, count)
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer, parameter :: NUM_REGIONS = 3
+  integer, intent(in) :: rank
+  integer, intent(in) :: sz
+  integer, dimension(1), intent(out) :: dims
+  integer, dimension(:), allocatable, intent(out) :: start
+  integer, dimension(:), allocatable, intent(out) :: count
+  integer :: i
+
+  dims(1) = sz * VEC_LOCAL_SZ * NUM_REGIONS
+  allocate(start(NUM_REGIONS))
+  allocate(count(NUM_REGIONS))
+
+  
+  do i=1,NUM_REGIONS
+    count(i) = VEC_LOCAL_SZ
+    start(i) = rank * VEC_LOCAL_SZ + (i-1) * (sz * VEC_LOCAL_SZ) + 1
+  end do
+
+END SUBROUTINE get_1d_bc_mreg_info
+
+! Test writes multiple variables before syncing and reading them back
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_wr_rd_1d_bc
+  implicit none
+  interface
+    subroutine get_1d_bc_info(rank, sz, dims, start, count, force_rearrange)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+      logical, intent(in) :: force_rearrange
+    end subroutine get_1d_bc_info
+  end interface
+  type(var_desc_t)  :: pio_var1, pio_var2, pio_var3
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: start, count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_1d_bc_info(pio_tf_world_rank_, pio_tf_world_sz_, dims,&
+         start, count, .true.)
+  allocate(wbuf(count(1)))
+  allocate(compdof(count(1)))
+  do i=1,count(1)
+    wbuf(i) = start(1) + i - 1
+    compdof(i) = start(1) + i - 1
+  end do
+  if(allocated(start))then
+    deallocate(start)
+  end if
+
+  if(allocated(count))then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, wr_iodesc)
+  deallocate(compdof)
+
+  ! Set the decomposition for reading data - different from the write decomp
+  call get_1d_bc_info(pio_tf_world_rank_, pio_tf_world_sz_, dims,&
+         start, count, .false.)
+  allocate(rbuf(count(1)))
+  allocate(compdof(count(1)))
+  allocate(exp_val(count(1)))
+  do i=1,count(1)
+    compdof(i) = start(1) + i -1
+    ! Expected value, after reading, is the same as the compdof
+    exp_val(i) = compdof(i)
+  end do
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, rd_iodesc)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var3', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variables out
+    call PIO_write_darray(pio_file, pio_var1, wr_iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, wr_iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var3, wr_iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, rd_iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var1) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val (var1)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, rd_iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var2) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val (var2)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var3, rd_iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var3) : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val (var3)")
+
+    call PIO_closefile(pio_file)
+    
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+  deallocate(exp_val)
+  deallocate(rbuf)
+  deallocate(wbuf)
+PIO_TF_AUTO_TEST_SUB_END nc_mvar_wr_rd_1d_bc
+
+! Test write/read of multiple variables before syncing
+! * Variables 1 & 3 - each proc writes/reads multiple regions
+!   of the data
+! * Variables 2 & 4 - each proc writes/reads 1 region
+!   (with data rearrangement)
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_mreg_wr_rd_1d_bc
+  implicit none
+  interface
+    subroutine get_1d_bc_info(rank, sz, dims, start, count, force_rearrange)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+      logical, intent(in) :: force_rearrange
+    end subroutine get_1d_bc_info
+    subroutine get_1d_bc_mreg_info(rank, sz, dims, start, count)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+    end subroutine get_1d_bc_mreg_info
+  end interface
+  type(var_desc_t)  :: pio_var1, pio_var2, pio_var3, pio_var4
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: iodesc_mreg, iodesc
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: start, count
+  integer :: total_count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf_mreg, wbuf_mreg
+  integer, dimension(1) :: dims, dims_mreg
+  integer :: pio_dim, pio_dim_mreg
+  integer :: i, j, idx, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Set the decomposition for writing data - forcing rearrangement
+  call get_1d_bc_info(pio_tf_world_rank_, pio_tf_world_sz_, dims,&
+         start, count, .true.)
+  allocate(wbuf(count(1)))
+  allocate(rbuf(count(1)))
+  allocate(compdof(count(1)))
+  do i=1,count(1)
+    wbuf(i) = start(1) + i - 1
+    compdof(i) = start(1) + i - 1
+  end do
+  rbuf = wbuf
+  if(allocated(start)) then
+    deallocate(start)
+  end if
+  if(allocated(count)) then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compdof, iodesc)
+  deallocate(compdof)
+
+  call get_1d_bc_mreg_info(pio_tf_world_rank_, pio_tf_world_sz_,&
+         dims_mreg, start, count)
+  total_count = 0
+  do i=1,size(count)
+    total_count = total_count + count(i) 
+  end do
+  allocate(wbuf_mreg(total_count))
+  allocate(rbuf_mreg(total_count))
+  allocate(compdof(total_count))
+  do i=1,size(count)
+    do j=1,count(i)
+      idx = (i-1)*count(i) + j
+      compdof(idx) = start(i) + j - 1
+      wbuf_mreg(idx) = compdof(idx)
+      rbuf_mreg(idx) = compdof(idx)
+    end do
+  end do
+  if(allocated(start)) then
+    deallocate(start)
+  end if
+  if(allocated(count)) then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims_mreg, compdof, iodesc_mreg)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_mreg', dims_mreg(1), pio_dim_mreg)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim (mreg) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1_mreg', PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var1) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var2) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var3_mreg', PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var3) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var4', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var4)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var4) : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variables out
+    call PIO_write_darray(pio_file, pio_var1, iodesc_mreg, wbuf_mreg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var1) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var2) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var3, iodesc_mreg, wbuf_mreg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var3) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var4, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var4) : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    rbuf_mreg = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc_mreg, rbuf_mreg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var1): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mreg, wbuf_mreg), "Got wrong val (var1)")
+
+    rbuf_mreg = 0
+    call PIO_read_darray(pio_file, pio_var3, iodesc_mreg, rbuf_mreg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var3): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mreg, wbuf_mreg), "Got wrong val (var2)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var2): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var2)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var4, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var4): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (var4)")
+
+    call PIO_closefile(pio_file)
+    
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc_mreg)
+  deallocate(rbuf)
+  deallocate(rbuf_mreg)
+  deallocate(wbuf)
+  deallocate(wbuf_mreg)
+PIO_TF_AUTO_TEST_SUB_END nc_mvar_mreg_wr_rd_1d_bc
+


### PR DESCRIPTION
This merge brings in,
* Tests that write multiple contiguous blocks of data from each
   MPI process
* Tests that write data with multiple contiguous blocks with fillvalues
* A test where the test only writes out 1 value (the rest are fillvalues)
* Tests for pio_syncfile()
* Fix for the case when the root I/O process only writes out fillvalues

Fixes #14 