### PR TITLE
Removing some stack-based variable-length arrays

### DIFF
--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -332,9 +332,16 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
         if (mcount[i] > 0)
         {
             int len = mcount[i] / blocksize;
-            int displace[len];
+            int *displace = NULL;
             LOG((3, "blocksize = %d i = %d mcount[%d] = %d len = %d", blocksize, i, i,
                  mcount[i], len));
+
+            if (len > 0)
+            {
+                if (!(displace = malloc(len * sizeof(int))))
+                    return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+            }
+
             if (blocksize == 1)
             {
                 if (!mfrom)
@@ -373,6 +380,9 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
             if ((mpierr = MPI_Type_create_indexed_block(len, blocksize, displace,
                                                         mpitype, &mtype[i])))
                 return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+
+            free(displace);
+            displace = NULL;
 
             if (mtype[i] == PIO_DATATYPE_NULL)
                 return pio_err(NULL, NULL, PIO_EINVAL, __FILE__, __LINE__);
@@ -526,8 +536,9 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     int nrecvs = 0;
     int ierr;
 
-    /* Check inputs. */
-    pioassert(ios && iodesc && dest_ioproc && dest_ioindex &&
+    /* Check inputs. If iodesc->ndof is 0, dest_ioproc and dest_ioindex can be NULL */
+    pioassert(ios && iodesc &&
+              (iodesc->ndof == 0 || (iodesc->ndof > 0 && dest_ioproc && dest_ioindex)) &&
               iodesc->rearranger == PIO_REARR_BOX && ios->num_uniontasks > 0,
               "invalid input", __FILE__, __LINE__);
     LOG((1, "compute_counts ios->num_uniontasks = %d", ios->num_uniontasks));
@@ -540,7 +551,12 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
     int recv_displs[ios->num_uniontasks];
 
     /* The list of indeces on each compute task */
-    PIO_Offset s2rindex[iodesc->ndof];
+    PIO_Offset *s2rindex = NULL;
+    if (iodesc->ndof > 0)
+    {
+        if (!(s2rindex = malloc(iodesc->ndof * sizeof(PIO_Offset))))
+          return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    }
 
     /* Allocate memory for the array of counts and init to zero. */
     if (!(iodesc->scount = calloc(ios->num_iotasks, sizeof(int))))
@@ -753,6 +769,9 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
                           recv_counts, recv_displs, sr_types, ios->union_comm,
                           &iodesc->rearr_opts.comp2io)))
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__);
+
+    free(s2rindex);
+    s2rindex = NULL;
 
     return PIO_NOERR;
 }
@@ -1183,8 +1202,8 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
          "ios->num_iotasks = %d", maplen, ndims, ios->num_comptasks, ios->num_iotasks));
 
     /* Allocate arrays needed for this function. */
-    int dest_ioproc[maplen]; /* Destination IO task for each data element on compute task. */
-    PIO_Offset dest_ioindex[maplen];    /* Offset into IO task array for each data element. */
+    int *dest_ioproc = NULL; /* Destination IO task for each data element on compute task. */
+    PIO_Offset *dest_ioindex = NULL;    /* Offset into IO task array for each data element. */
     int sendcounts[ios->num_uniontasks]; /* Send counts for swapm call. */
     int sdispls[ios->num_uniontasks];    /* Send displacements for swapm. */
     int recvcounts[ios->num_uniontasks]; /* Receive counts for swapm. */
@@ -1197,6 +1216,15 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
 
     /* Number of elements of data on compute node. */
     iodesc->ndof = maplen;
+
+    if (maplen > 0)
+    {
+        if (!(dest_ioproc = malloc(maplen * sizeof(int))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+
+        if (!(dest_ioindex = malloc(maplen * sizeof(PIO_Offset))))
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    }
 
     /* Initialize array values. */
     for (int i = 0; i < maplen; i++)
@@ -1375,6 +1403,11 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     LOG((2, "calling compute_counts maplen = %d", maplen));
     if ((ret = compute_counts(ios, iodesc, dest_ioproc, dest_ioindex)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
+
+    free(dest_ioproc);
+    free(dest_ioindex);
+    dest_ioproc = NULL;
+    dest_ioindex = NULL;
 
     /* Compute the max io buffer size needed for an iodesc. */
     if (ios->ioproc)
@@ -1879,7 +1912,13 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
         }
 
         /* Allocate and initialize a grid to fill in missing values. ??? */
-        PIO_Offset grid[thisgridsize[ios->io_rank]];
+        PIO_Offset *grid = NULL;
+        if (thisgridsize[ios->io_rank] > 0)
+        {
+            if (!(grid = malloc(thisgridsize[ios->io_rank] * sizeof(PIO_Offset))))
+                return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
+
         for (i = 0; i < thisgridsize[ios->io_rank]; i++)
             grid[i] = 0;
 
@@ -1921,6 +1960,8 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
                     return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__);
             }
         }
+        free(grid);
+        grid = NULL;
         maxregions = 0;
         iodesc->maxfillregions = 0;
         if (myfillgrid)

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -338,7 +338,7 @@ int create_mpi_datatypes(MPI_Datatype mpitype, int msgcnt,
 
             if (len > 0)
             {
-                if (!(displace = malloc(len * sizeof(int))))
+                if (!(displace = calloc(len, sizeof(int))))
                     return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
             }
 

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -222,14 +222,13 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
             numgaps = ii;
         }
 
-        PIO_Offset *loc_arr = NULL;
-        if (arrlen > 1)
-        {
-            if (!(loc_arr = malloc((arrlen - 1) * sizeof(PIO_Offset))))
-                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
-        }
+        /* If numblks > 1 then arrlen must be > 1 */
+        PIO_Offset *loc_arr = calloc(arrlen - 1, sizeof(PIO_Offset));
+        if (!loc_arr)
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
 
         j = 0;
+        /* If numblks > 1 then n must be <= (arrlen - 1) */
         for (int i = 0; i < n; i++)
             loc_arr[i] = 1;
 
@@ -239,6 +238,7 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
 
         blk_len[0] = loc_arr[0];
         blklensum = blk_len[0];
+        /* If numblks > 1 then numblks must be <= arrlen */
         for(int i = 1; i < numblks - 1; i++)
         {
             blk_len[i] = loc_arr[i] - loc_arr[i - 1];

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -166,11 +166,16 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
     PIO_Offset bsize;     /* Size of the block. */
     PIO_Offset bsizeg;    /* Size of gap block. */
     PIO_Offset blklensum; /* Sum of all block lengths. */
-    PIO_Offset del_arr[arrlen - 1]; /* Array of deltas between adjacent elements in arr_in. */
-    PIO_Offset loc_arr[arrlen - 1];
+    PIO_Offset *del_arr = NULL; /* Array of deltas between adjacent elements in arr_in. */
 
     /* Check inputs. */
     pioassert(arrlen > 0 && arr_in, "invalid input", __FILE__, __LINE__);
+
+    if (arrlen > 1)
+    {
+        if (!(del_arr = malloc((arrlen - 1) * sizeof(PIO_Offset))))
+            return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+    }
 
     /* Count the number of contiguous blocks in arr_in. If any if
        these blocks is of size 1, we are done and can return.
@@ -182,7 +187,11 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
         {
             numtimes++;
             if ( i > 0 && del_arr[i - 1] > 1)
+            {
+                free(del_arr);
+                del_arr = NULL;
                 return(1);
+            }
         }
     }
 
@@ -213,6 +222,13 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
             numgaps = ii;
         }
 
+        PIO_Offset *loc_arr = NULL;
+        if (arrlen > 1)
+        {
+            if (!(loc_arr = malloc((arrlen - 1) * sizeof(PIO_Offset))))
+                return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__);
+        }
+
         j = 0;
         for (int i = 0; i < n; i++)
             loc_arr[i] = 1;
@@ -228,6 +244,8 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
             blk_len[i] = loc_arr[i] - loc_arr[i - 1];
             blklensum += blk_len[i];
         }
+        free(loc_arr);
+        loc_arr = NULL;
         blk_len[numblks - 1] = arrlen - blklensum;
 
         /* Get the GCD in blk_len array. */
@@ -247,7 +265,10 @@ PIO_Offset GCDblocksize(int arrlen, const PIO_Offset *arr_in)
         if (arr_in[0] > 0)
             bsize = lgcd(bsize, arr_in[0]);
     }
-    
+
+    free(del_arr);
+    del_arr = NULL;
+
     return bsize;
 }
 

--- a/tests/general/pio_large_file_tests.F90.in
+++ b/tests/general/pio_large_file_tests.F90.in
@@ -307,3 +307,104 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_def_large_1d_bc
   end if
 PIO_TF_AUTO_TEST_SUB_END nc_def_large_1d_bc
 
+! nc write large 1d array with fillvalues (the holes are implicit)
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_large_1d_fval
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 1000000
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(io_desc_t) :: wiodesc, riodesc
+  integer, dimension(:), allocatable :: wcompdof
+  integer :: wcompdof_sz
+  integer, dimension(VEC_LOCAL_SZ) :: rcompdof, compdof_rel_disps
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: wbuf
+  PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: rbuf, exp_val
+  ! The buffer fillvalue to be used when writing data
+  PIO_TF_FC_DATA_TYPE, PARAMETER :: BUF_FILLVAL = -2
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! compdof is only specified for valid data values, the data holes are
+  ! implicitly stated (by not specifying them rather than filling it with 0s)
+  wcompdof_sz = min(pio_tf_world_rank_+1, VEC_LOCAL_SZ) 
+  allocate(wcompdof(wcompdof_sz))
+  allocate(wbuf(wcompdof_sz))
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  ! rank 0 has 1 valid data value, rank 2 has 2 data values and so on...
+  do i=1,wcompdof_sz
+    wcompdof(i) = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps(i)
+  end do
+  ! Read everything - including fillvalues that should have been 
+  ! written for locations unspecified in wcompdof(:) i.e.,
+  ! wcompdof(wcompdof_sz:VEC_LOCAL_SZ]
+  rcompdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+
+  wbuf = 0
+  ! The first wcompdof_sz values, wbuf[1:wcompdof_sz], are valid in wbuf
+  do i=1,wcompdof_sz
+    wbuf(i) = wcompdof(i)
+    exp_val(i) = wbuf(i)
+  end do
+  ! We expect the values (wcompdof_sz:VEC_LOCAL_SZ] to be read as 
+  ! user specified fill values
+  do i=wcompdof_sz+1,VEC_LOCAL_SZ
+    exp_val(i) = BUF_FILLVAL
+  end do
+  rbuf = 0
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, wcompdof, wiodesc)
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, rcompdof, riodesc)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_fillval_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER) 
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variable out, user specified fillvalue = BUF_FILLVAL
+    call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+    call PIO_syncfile(pio_file)
+
+    call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename)
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, riodesc)
+  call PIO_freedecomp(pio_tf_iosystem_, wiodesc)
+  deallocate(wbuf)
+  deallocate(wcompdof)
+PIO_TF_AUTO_TEST_SUB_END nc_write_large_1d_fval
+


### PR DESCRIPTION
Fixing failures on machines with limited stack size due to stack 
based variable length arrays.

Modifying Fortran unit test pio_decomp_fillval to reproduce issues
caused by some stack-based variable-length arrays on machines with
limited stack size. Converting some stack-based variable-length
arrays to heap-based ones such that the modified Fortran test can
pass on those machines.

Fixes #17