### PR TITLE
Updating Fortran unit test nc_wr_1d_const_buf_sz

### DIFF
--- a/tests/general/pio_decomp_tests.F90.in
+++ b/tests/general/pio_decomp_tests.F90.in
@@ -107,7 +107,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
   integer, parameter :: MAX_VEC_SZ = 2
   integer, parameter :: VEC_LOCAL_SZ_ODD = MAX_VEC_SZ - 1
   integer, parameter :: VEC_LOCAL_SZ_EVEN = MAX_VEC_SZ
-  type(var_desc_t)  :: pio_var
+  type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
   type(io_desc_t) :: iodesc
@@ -141,7 +141,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
   allocate(compdof(cdof_sz))
   allocate(compdof_rel_disps(cdof_sz))
   wbuf = 0
-  rbuf = 0
   do i=1,cdof_sz
     compdof_rel_disps(i) = i
     wbuf(i) = i
@@ -168,22 +167,36 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
-    PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define first var : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define second var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
 
-    ! Write the variable out
-    call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+    ! Write first variable out
+    call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write first darray : " // trim(filename))
+
+    ! Write second variable out
+    call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write second darray : " // trim(filename))
 
     call PIO_syncfile(pio_file)
 
-    call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ierr)
-    PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read first darray : " // trim(filename))
 
-    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val")
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (first var)")
+
+    rbuf = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc, rbuf, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read second darray : " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf, wbuf), "Got wrong val (second var)")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);


### PR DESCRIPTION
Write two variables (instead of one in original test) using the same
decomposition. This change can additionally test the case when the
write multi-buffer holds data from more than one variable, which is
common in some ACME tests (e.g. ERS_Ln9.ne4_ne4.FC5AV1C-L).

Reproduces issue #20