### PR TITLE
Truncating the array length passed to PIOc_write_darray

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -488,13 +488,15 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
     /* Check that the local size of the variable passed in matches the
      * size expected by the io descriptor. Fail if arraylen is too
-     * small, just put a warning in the log if it is too big (the
-     * excess values will be ignored.) */
+     * small, just put a warning in the log and truncate arraylen
+     * if it is too big (the excess values will be ignored.) */
     if (arraylen < iodesc->ndof)
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__);
     LOG((2, "%s arraylen = %d iodesc->ndof = %d",
-         (iodesc->ndof != arraylen) ? "WARNING: iodesc->ndof != arraylen" : "",
+         (arraylen > iodesc->ndof) ? "WARNING: arraylen > iodesc->ndof" : "",
          arraylen, iodesc->ndof));
+    if (arraylen > iodesc->ndof)
+        arraylen = iodesc->ndof;
 
     /* Get var description. */
     vdesc = &(file->varlist[varid]);


### PR DESCRIPTION
For PIOc_write_darray, when the passed in array length is larger
than expected, the excess values should be ignored. Otherwise,
some junk data might be rearranged to IO tasks and written to
the output files.

This issue was initially found with acme_developer test
ERS_Ln9.ne4_ne4.FC5AV1C-L. It can also be reproduced
with updated Fortran unit test nc_wr_1d_const_buf_sz

Fixes #20