### PR TITLE
Fixing randomly failed C unit test test_rearr

### DIFF
--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -499,6 +499,7 @@ int test_define_iodesc_datatypes()
 
         /* Set up test for IO task with BOX rearranger to create one type. */
         ios.ioproc = 1; /* this is IO proc. */
+        ios.compproc = 1; /* this is also compute proc. */
         ios.num_iotasks = 4; /* The number of IO tasks. */
         iodesc.rtype = NULL; /* Array of MPI types will be created here. */
         iodesc.nrecvs = 1; /* Number of types created. */


### PR DESCRIPTION
In CDash, test_rearr fails randomly on MPI_Type_free, due to an
uninitialized value in test_define_iodesc_datatypes. So far, this fix
is in NCAR/ParallelIO, but not in ACME-Climate/ParallelIO yet.

Fixes NCAR/ParallelIO/#1197