### PR TITLE
Adding support for theta

### DIFF
--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -45,6 +45,11 @@ function (platform_name RETURN_VARIABLE)
         
         set (${RETURN_VARIABLE} "alcf" PARENT_SCOPE)
         
+    # ALCF theta
+    elseif (SITENAME MATCHES "^theta")
+
+        set (${RETURN_VARIABLE} "alcf_theta" PARENT_SCOPE)
+
     # NERSC Machines
     elseif (SITENAME MATCHES "^edison" OR
         SITENAME MATCHES "^cori")

--- a/cmake/mpiexec.alcf_theta
+++ b/cmake/mpiexec.alcf_theta
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Arguments:
+#
+#   $1  - Number of MPI Tasks
+#   $2+ - Executable and its arguments
+#
+
+NP=$1
+shift
+
+aprun -n $NP $@


### PR DESCRIPTION
Adding support for theta@ALCF (uses cray+aprun)

This change would all tests to run out of the box within
a cobalt job script on theta.