### PR TITLE
Fix warnings related to micro timers

### DIFF
--- a/src/clib/pio_mpi_timer.c
+++ b/src/clib/pio_mpi_timer.c
@@ -16,6 +16,7 @@ int mpi_mtimer_init(void )
 int mpi_mtimer_finalize(void )
 {
     /* Nothing to do here */
+    return PIO_NOERR;
 }
 
 double mpi_mtimer_get_wtime(void )

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1086,12 +1086,14 @@ int PIOc_finalize(int iosysid)
     if ((ierr = pio_delete_iosystem_from_list(iosysid)))
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
 
+#ifdef PIO_MICRO_TIMING
     ierr = mtimer_finalize();
     if(ierr != PIO_NOERR)
     {
         /* log and continue */
         LOG((1, "Finalizing micro timers failed"));
     }
+#endif
 
     LOG((1, "about to finalize logging"));
     pio_finalize_logging();


### PR DESCRIPTION
Fixing warnings related to the recent merge of micro timers.

Fixes #33 
