### PR TITLE
Adding internal GPTL timing summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ mark_as_advanced(VERSION_MAJOR VERSION_MINOR VERSION_PATCH)
 #===== Library Options =====
 option (PIO_ENABLE_FORTRAN   "Enable the Fortran library builds"            ON)
 option (PIO_ENABLE_TIMING    "Enable the use of the GPTL timing library"    ON)
+option (PIO_ENABLE_INTERNAL_TIMING    "Gather and print GPTL timing stats"  OFF)
 option (PIO_ENABLE_LOGGING   "Enable debug logging (large output possible)" OFF)
 option (PIO_ENABLE_DOC       "Enable building PIO documentation"            ON)
 option (PIO_ENABLE_COVERAGE  "Enable code coverage"                         OFF)

--- a/examples/c/darray_async.c
+++ b/examples/c/darray_async.c
@@ -227,9 +227,11 @@ data:
 	int ret;                        /* Return value. */
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
 	/* Initialize the GPTL timing library. */
 	if ((ret = GPTLinitialize ()))
 	    return ret;
+#endif
 #endif
         
 	/* Initialize MPI. */
@@ -377,9 +379,11 @@ data:
 	MPI_Finalize();
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
 	/* Finalize the GPTL timing library. */
 	if ((ret = GPTLfinalize ()))
 	    return ret;
+#endif
 #endif
 
         printf("rank: %d SUCCESS!\n", my_rank);

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -219,9 +219,11 @@ data:
 	int ret;                        /* Return value. */
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
 	/* Initialize the GPTL timing library. */
 	if ((ret = GPTLinitialize ()))
 	    return ret;
+#endif
 #endif
 
 	/* Initialize MPI. */
@@ -348,9 +350,11 @@ data:
 	MPI_Finalize();
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
 	/* Finalize the GPTL timing library. */
 	if ((ret = GPTLfinalize ()))
 	    return ret;
+#endif
 #endif
 
         printf("rank: %d SUCCESS!\n", my_rank);

--- a/examples/c/example1.c
+++ b/examples/c/example1.c
@@ -277,9 +277,11 @@ int check_file(int ntasks, char *filename) {
 	    }
 
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
 	/* Initialize the GPTL timing library. */
 	if ((ret = GPTLinitialize ()))
 	    return ret;
+#endif
 #endif    
     
 	/* Initialize MPI. */
@@ -411,9 +413,11 @@ int check_file(int ntasks, char *filename) {
 	MPI_Finalize();
 
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
 	/* Finalize the GPTL timing library. */
 	if ((ret = GPTLfinalize ()))
 	    return ret;
+#endif
 #endif    
 
 	if (verbose)

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -451,9 +451,11 @@ int main(int argc, char* argv[])
 	}
 
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize ()))
 	return ret;
+#endif
 #endif    
     
     /* Initialize MPI. */
@@ -678,9 +680,11 @@ int main(int argc, char* argv[])
     MPI_Finalize();
 
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize ()))
 	return ret;
+#endif
 #endif    
 
     if (verbose)

--- a/examples/c/examplePio.c
+++ b/examples/c/examplePio.c
@@ -576,10 +576,12 @@ int main(int argc, char* argv[])
     struct examplePioClass* pioExInst = epc_new(verbose);
     
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     int ret;
     if ((ret = GPTLinitialize ()))
       return ret;
+#endif
 #endif    
     
     pioExInst->init(pioExInst);
@@ -592,9 +594,11 @@ int main(int argc, char* argv[])
     pioExInst->cleanUp(pioExInst);
     
 #ifdef TIMING    
+#ifndef TIMING_INTERNAL
 	/* Finalize the GPTL timing library. */
 	if ((ret = GPTLfinalize ()))
 	    return ret;
+#endif
 #endif    
 
     free(pioExInst);

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -84,6 +84,10 @@ if (PIO_ENABLE_TIMING)
   endif ()
   target_compile_definitions (pioc
     PUBLIC TIMING)
+  if (PIO_ENABLE_INTERNAL_TIMING)
+    target_compile_definitions (pioc
+      PUBLIC TIMING_INTERNAL)
+  endif ()
 endif ()
 
 #====== PIO_MICRO_TIMING ======

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -353,6 +353,10 @@ extern "C" {
     void pio_init_logging(void);
     void pio_finalize_logging(void );
 
+    /* Initialize and finalize GPTL timers. */
+    void pio_init_gptl(void);
+    void pio_finalize_gptl(void );
+
     /* Internal mpi timer impl functions */
     int mpi_mtimer_init(void );
     int mpi_mtimer_finalize(void );

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -128,6 +128,9 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
         if ((mpierr = MPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                     recvcounts, rdispls, recvtypes, comm)))
             return check_mpi(NULL, mpierr, __FILE__, __LINE__);
+#ifdef TIMING
+        GPTLstop("PIO:pio_swapm");
+#endif
         return PIO_NOERR;
     }
 
@@ -174,7 +177,12 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
     /* When send to self is complete there is nothing left to do if
      * ntasks==1. */
     if (ntasks == 1)
+    {
+#ifdef TIMING
+        GPTLstop("PIO:pio_swapm");
+#endif
         return PIO_NOERR;
+    }
 
     for (int i = 0; i < ntasks; i++)
     {
@@ -201,7 +209,12 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
     LOG((3, "steps=%d", steps));
 
     if (steps == 0)
+    {
+#ifdef TIMING
+        GPTLstop("PIO:pio_swapm");
+#endif
         return PIO_NOERR;
+    }
 
     if (steps == 1)
     {

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -764,7 +764,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
  */
 #ifdef TIMING
 #ifdef TIMING_INTERNAL
-    GPTLinitialize();
+    pio_init_gptl();
 #endif
     GPTLstart("PIO:PIOc_Init_Intracomm");
 #endif
@@ -1115,7 +1115,7 @@ int PIOc_finalize(int iosysid)
         GPTLpr_file(gptl_log_fname);
         LOG((2, "Finished writing gptl summary"));
     }
-    GPTLfinalize();
+    pio_finalize_gptl();
 #endif
 #endif
     if (ios->union_comm != MPI_COMM_NULL)
@@ -1294,7 +1294,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
  */
 #ifdef TIMING
 #ifdef TIMING_INTERNAL
-    GPTLinitialize();
+    pio_init_gptl();
 #endif
     GPTLstart("PIO:PIOc_init_async");
 #endif

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -759,7 +759,13 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     int mpierr;        /* Return value for MPI calls. */
     int ret;           /* Return code for function calls. */
 
+/* TIMING_INTERNAL implies that the timing statistics are gathered/
+ * displayed by pio
+ */
 #ifdef TIMING
+#ifdef TIMING_INTERNAL
+    GPTLinitialize();
+#endif
     GPTLstart("PIO:PIOc_Init_Intracomm");
 #endif
     /* Turn on the logging system. */
@@ -991,6 +997,10 @@ int PIOc_finalize(int iosysid)
     int niosysid;          /* The number of currently open IO systems. */
     int mpierr = MPI_SUCCESS, mpierr2;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;
+#ifdef TIMING_INTERNAL
+    char gptl_iolog_fname[PIO_MAX_NAME];
+    char gptl_log_fname[PIO_MAX_NAME];
+#endif
 
 #ifdef TIMING
     GPTLstart("PIO:PIOc_finalize");
@@ -1068,10 +1078,6 @@ int PIOc_finalize(int iosysid)
      * handed into init_intercomm. So they need to be freed by MPI. */
     if (ios->intercomm != MPI_COMM_NULL)
         MPI_Comm_free(&ios->intercomm);
-    if (ios->union_comm != MPI_COMM_NULL)
-        MPI_Comm_free(&ios->union_comm);
-    if (ios->io_comm != MPI_COMM_NULL)
-        MPI_Comm_free(&ios->io_comm);
     if (ios->comp_comm != MPI_COMM_NULL)
         MPI_Comm_free(&ios->comp_comm);
     if (ios->my_comm != MPI_COMM_NULL)
@@ -1080,11 +1086,6 @@ int PIOc_finalize(int iosysid)
     /* Free the MPI Info object. */
     if (ios->info != MPI_INFO_NULL)
         MPI_Info_free(&ios->info);
-
-    /* Delete the iosystem_desc_t data associated with this id. */
-    LOG((2, "About to delete iosysid %d.", iosysid));
-    if ((ierr = pio_delete_iosystem_from_list(iosysid)))
-        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
 
 #ifdef PIO_MICRO_TIMING
     ierr = mtimer_finalize();
@@ -1101,7 +1102,32 @@ int PIOc_finalize(int iosysid)
     LOG((2, "PIOc_finalize completed successfully"));
 #ifdef TIMING
     GPTLstop("PIO:PIOc_finalize");
+#ifdef TIMING_INTERNAL
+    if(ios->io_comm != MPI_COMM_NULL)
+    {
+        snprintf(gptl_iolog_fname, PIO_MAX_NAME, "piorwgptlioinfo%010dwrank.dat", ios->ioroot);
+        GPTLpr_summary_file(ios->io_comm, gptl_iolog_fname);
+        LOG((2, "Finished writing gptl io proc summary"));
+    }
+    snprintf(gptl_log_fname, PIO_MAX_NAME, "piorwgptlinfo%010dwrank.dat", ios->ioroot);
+    if(ios->io_rank == 0)
+    {
+        GPTLpr_file(gptl_log_fname);
+        LOG((2, "Finished writing gptl summary"));
+    }
+    GPTLfinalize();
 #endif
+#endif
+    if (ios->union_comm != MPI_COMM_NULL)
+        MPI_Comm_free(&ios->union_comm);
+    if (ios->io_comm != MPI_COMM_NULL)
+        MPI_Comm_free(&ios->io_comm);
+
+    /* Delete the iosystem_desc_t data associated with this id. */
+    LOG((2, "About to delete iosysid %d.", iosysid));
+    if ((ierr = pio_delete_iosystem_from_list(iosysid)))
+        return pio_err(NULL, NULL, ierr, __FILE__, __LINE__);
+
     return PIO_NOERR;
 }
 
@@ -1263,7 +1289,13 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
     int mpierr;           /* Return code from MPI functions. */
     int ret;              /* Return code. */
 
+/* TIMING_INTERNAL implies that the timing statistics are gathered/
+ * displayed by pio
+ */
 #ifdef TIMING
+#ifdef TIMING_INTERNAL
+    GPTLinitialize();
+#endif
     GPTLstart("PIO:PIOc_init_async");
 #endif
     /* Check input parameters. */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -24,6 +24,7 @@ int pio_log_ref_cnt = 0;
 int my_rank;
 FILE *LOG_FILE = NULL;
 #endif /* PIO_ENABLE_LOGGING */
+int pio_timer_ref_cnt = 0;
 
 /**
  * The PIO library maintains its own set of ncids. This is the next
@@ -165,6 +166,36 @@ void pio_finalize_logging(void)
                  pio_log_ref_cnt));
     }
 #endif /* PIO_ENABLE_LOGGING */
+}
+
+/**
+ * Initialize GPTL timer library, if needed
+ * The library is only initialized if the timing is internal
+ */
+void pio_init_gptl(void )
+{
+#ifdef TIMING_INTERNAL
+    pio_timer_ref_cnt += 1;
+    if(pio_timer_ref_cnt == 1)
+    {
+        GPTLinitialize();
+    }
+#endif
+}
+
+/**
+ * Finalize GPTL timer library, if needed
+ * The library is only finalized if the timing is internal
+ */
+void pio_finalize_gptl(void)
+{
+#ifdef TIMING_INTERNAL
+    pio_timer_ref_cnt -= 1;
+    if(pio_timer_ref_cnt == 0)
+    {
+        GPTLfinalize();
+    }
+#endif
 }
 
 #if PIO_ENABLE_LOGGING

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -141,9 +141,11 @@ int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks,
     int ret; /* Return value. */
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize()))
         return ERR_GPTL;
+#endif
 #endif
 
     /* Initialize MPI. */
@@ -225,9 +227,11 @@ int pio_test_finalize(MPI_Comm *test_comm)
     MPI_Finalize();
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize()))
         return ret;
+#endif
 #endif
 
     return ret;

--- a/tests/general/test_memleak.c
+++ b/tests/general/test_memleak.c
@@ -181,9 +181,11 @@ main(int argc, char **argv)
     int ret;
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize ()))
 	return ret;
+#endif
 #endif
 
     /* Initialize MPI. */
@@ -342,9 +344,11 @@ main(int argc, char **argv)
     MPI_Finalize();
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize ()))
 	return ret;
+#endif
 #endif
 
     return 0;

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -124,7 +124,9 @@ CONTAINS
     CALL MPI_COMM_RANK(pio_tf_comm_, pio_tf_world_rank_, ierr)
     CALL MPI_COMM_SIZE(pio_tf_comm_, pio_tf_world_sz_, ierr)
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     call t_initf('gptl.nl')
+#endif
 #endif
 
 
@@ -197,7 +199,9 @@ CONTAINS
     CALL MPI_COMM_FREE(pio_tf_comm_, ierr);
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     call t_finalizef()
+#endif
 #endif
   END SUBROUTINE PIO_TF_Finalize_
 


### PR DESCRIPTION
Adding an option to gather and log GPTL timing
statistics in PIO.

If users build PIO with "PIO_ENABLE_TIMING" and
"PIO_ENABLE_INTERNAL_TIMING" the GPTL timing
statistics is automatically logged into files named
"piorwgptl*.dat"