### PR TITLE
Fix write micro timer when data is flushed out

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -749,23 +749,21 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if ((ierr = flush_buffer(ncid, wmb, needsflush == 2)))
             return pio_err(ios, file, ierr, __FILE__, __LINE__);
     }
-    else
-    {
-        /* One record size (sum across all procs) of data is buffered */
-        file->varlist[varid].wb_pend += file->varlist[varid].vrsize;
-        file->wb_pend += file->varlist[varid].vrsize;
-        LOG((1, "Current pending bytes for ncid=%d, varid=%d var_wb_pend= %llu, file_wb_pend=%llu",
-              ncid, varid,
-              (unsigned long long int) file->varlist[varid].wb_pend,
-              (unsigned long long int) file->wb_pend
-        ));
-        /* Buffering data is considered an async event (to indicate
-          *that the event is not yet complete)
-          */
+
+    /* One record size (sum across all procs) of data is buffered */
+    file->varlist[varid].wb_pend += file->varlist[varid].vrsize;
+    file->wb_pend += file->varlist[varid].vrsize;
+    LOG((1, "Current pending bytes for ncid=%d, varid=%d var_wb_pend= %llu, file_wb_pend=%llu",
+          ncid, varid,
+          (unsigned long long int) file->varlist[varid].wb_pend,
+          (unsigned long long int) file->wb_pend
+    ));
+    /* Buffering data is considered an async event (to indicate
+      *that the event is not yet complete)
+      */
 #ifdef PIO_MICRO_TIMING
-        mtimer_async_event_in_progress(file->varlist[varid].wr_mtimer, true);
+    mtimer_async_event_in_progress(file->varlist[varid].wr_mtimer, true);
 #endif
-    }
 
 #if PIO_USE_MALLOC
     /* Try realloc again if there is a flush. */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1249,8 +1249,8 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
         int request[reqcnt];
         int status[reqcnt];
 #ifdef PIO_MICRO_TIMING
-        bool var_has_pend_reqs[maxreq];
-        bool var_timer_was_running[maxreq];
+        bool var_has_pend_reqs[maxreq + 1];
+        bool var_timer_was_running[maxreq + 1];
         mtimer_t tmp_mt;
 
         /* Temp timer to keep track of wait time */

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1230,10 +1230,10 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     if (force || usage >= pio_buffer_size_limit)
     {
         int rcnt;
-        int  maxreq;
+        int  maxreq; /* Index of the last vdesc with pending requests */
         int reqcnt;
         int nvars_with_reqs = 0;
-        maxreq = 0;
+        maxreq = -1;
         reqcnt = 0;
         rcnt = 0;
         for (int i = 0; i < PIO_MAX_VARS; i++)


### PR DESCRIPTION
This PR fixes,

* The write times recorded by the micro timer when data is 
   flushed out.
* Fixes processing of vdescs with pending requests. Without the 
  fix the size of the array used to store information on vdescs was
  incorrect.