### PR TITLE
Fix build issues with pioperf_rearr on Theta

### DIFF
--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -561,10 +561,16 @@ contains
   subroutine get_tstamp(wall, sys, usr)
     use perf_mod
     double precision, intent(out) :: wall, sys, usr
-    external :: gptlstamp
+    interface
+      function gptlstamp(wall, sys, usr)
+        integer :: gptlstamp
+        double precision, intent(out) :: wall, sys, usr
+      end function
+    end interface
+    integer :: ierr
 
     if(use_gptl) then
-      call gptlstamp(wall, sys, usr)
+      ierr = gptlstamp(wall, sys, usr)
     else
       call t_stampf(wall, sys, usr)
     end if


### PR DESCRIPTION
Using an interface for the gptlstamp() function instead of
declaring it as an external function.

This is required to build the pioperf_rearr tool on
Theta (cray compiler).

Fixes #59 