### PR TITLE
Interface changes on inq_varname

### DIFF
--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -134,7 +134,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     }
 
     /* Check the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, var_name, &xtype, &ndims, dimids, &natts)))
+    if ((ret = PIOc_inq_var(ncid, 0, var_name, NC_MAX_NAME, &xtype, &ndims, dimids, &natts)))
         return ret;
     if (xtype != NC_INT || ndims != NDIM3 || dimids[0] != 0 || dimids[1] != 1 ||
             dimids[2] != 2 || natts != 0)

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -253,10 +253,10 @@ typedef struct var_desc_t
     int varid;
 
     /* Variable name - cached */
-    char vname[PIO_MAX_NAME];
+    char vname[PIO_MAX_NAME + 1];
 
     /* Variable description */
-    char vdesc[PIO_MAX_NAME];
+    char vdesc[PIO_MAX_NAME + 1];
     
     /* Non-zero if this is a record var (i.e. uses unlimited
      * dimension). */
@@ -706,7 +706,7 @@ typedef struct file_desc_t
     int fh;
 
     /* File name - cached */
-    char fname[PIO_MAX_NAME];
+    char fname[PIO_MAX_NAME + 1];
 
     /** The ncid that will be returned to the user. */
     int pio_ncid;
@@ -922,9 +922,9 @@ extern "C" {
 
     /* Variables. */
     int PIOc_inq_varid(int ncid, const char *name, int *varidp);
-    int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp, int *dimidsp,
-                     int *nattsp);
-    int PIOc_inq_varname(int ncid, int varid, char *name);
+    int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, int *ndimsp,
+                     int *dimidsp, int *nattsp);
+    int PIOc_inq_varname(int ncid, int varid, char *name, int namelen);
     int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep);
     int PIOc_inq_varndims(int ncid, int varid, int *ndimsp);
     int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp);

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -1078,7 +1078,7 @@ int inq_var_handler(iosystem_desc_t *ios)
         nattsp = &natts;
 
     /* Call the inq function to get the values. */
-    if ((ret = PIOc_inq_var(ncid, varid, namep, xtypep, ndimsp, dimidsp, nattsp)))
+    if ((ret = PIOc_inq_var(ncid, varid, namep, NC_MAX_NAME + 1, xtypep, ndimsp, dimidsp, nattsp)))
         return pio_err(ios, NULL, ret, __FILE__, __LINE__);
 
     if (ndims_present)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -765,7 +765,7 @@ int PIOc_inq_dimid(int ncid, const char *name, int *idp)
  * @return PIO_NOERR for success, error code otherwise.
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
+int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, int *ndimsp,
                  int *dimidsp, int *nattsp)
 {
     iosystem_desc_t *ios;
@@ -847,9 +847,10 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
             }
             if (!ierr)
                 ierr = ncmpi_inq_var(file->fh, varid, my_name, xtypep, ndimsp, (dimidsp)?dimidsp:tmp_dimidsp, nattsp);
-            if (!ierr && name)
+            if (!ierr && name && namelen > 0)
             {
-                strncpy(name, my_name, PIO_MAX_NAME);
+                assert(namelen <= PIO_MAX_NAME + 1);
+                strncpy(name, my_name, namelen);
             }
             if(!ierr && (file->num_unlim_dimids > 0))
             {
@@ -932,9 +933,10 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
         return check_mpi(file, mpierr, __FILE__, __LINE__);
     if ((mpierr = MPI_Bcast((void *)my_name, slen + 1, MPI_CHAR, ios->ioroot, ios->my_comm)))
         return check_mpi(file, mpierr, __FILE__, __LINE__);
-    if (name)
+    if (name && namelen > 0)
     {
-        strncpy(name, my_name, PIO_MAX_NAME);
+        assert(namelen <= PIO_MAX_NAME + 1);
+        strncpy(name, my_name, namelen);
     }
     strncpy(file->varlist[varid].vname, my_name, PIO_MAX_NAME);
 
@@ -1016,12 +1018,13 @@ int PIOc_inq_var(int ncid, int varid, char *name, nc_type *xtypep, int *ndimsp,
  * @param ncid the ncid of the open file.
  * @param varid the variable ID.
  * @param name a pointer that will get the variable name.
+ * @param namelen the size of the user buffer pointed by name.
  * @return PIO_NOERR for success, error code otherwise.
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_inq_varname(int ncid, int varid, char *name)
+int PIOc_inq_varname(int ncid, int varid, char *name, int namelen)
 {
-    return PIOc_inq_var(ncid, varid, name, NULL, NULL, NULL, NULL);
+    return PIOc_inq_var(ncid, varid, name, namelen, NULL, NULL, NULL, NULL);
 }
 
 /**
@@ -1037,7 +1040,7 @@ int PIOc_inq_varname(int ncid, int varid, char *name)
  */
 int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep)
 {
-    return PIOc_inq_var(ncid, varid, NULL, xtypep, NULL, NULL, NULL);
+    return PIOc_inq_var(ncid, varid, NULL, 0, xtypep, NULL, NULL, NULL);
 }
 
 /**
@@ -1053,7 +1056,7 @@ int PIOc_inq_vartype(int ncid, int varid, nc_type *xtypep)
  */
 int PIOc_inq_varndims(int ncid, int varid, int *ndimsp)
 {
-    return PIOc_inq_var(ncid, varid, NULL, NULL, ndimsp, NULL, NULL);
+    return PIOc_inq_var(ncid, varid, NULL, 0, NULL, ndimsp, NULL, NULL);
 }
 
 /**
@@ -1069,7 +1072,7 @@ int PIOc_inq_varndims(int ncid, int varid, int *ndimsp)
  */
 int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp)
 {
-    return PIOc_inq_var(ncid, varid, NULL, NULL, NULL, dimidsp, NULL);
+    return PIOc_inq_var(ncid, varid, NULL, 0, NULL, NULL, dimidsp, NULL);
 }
 
 /**
@@ -1085,7 +1088,7 @@ int PIOc_inq_vardimid(int ncid, int varid, int *dimidsp)
  */
 int PIOc_inq_varnatts(int ncid, int varid, int *nattsp)
 {
-    return PIOc_inq_var(ncid, varid, NULL, NULL, NULL, NULL, nattsp);
+    return PIOc_inq_var(ncid, varid, NULL, 0, NULL, NULL, NULL, nattsp);
 }
 
 /**

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2577,7 +2577,7 @@ int calc_var_rec_sz(int ncid, int varid)
     }
 
     /* Calculate and cache the size of a single record/timestep */
-    ierr = PIOc_inq_var(ncid, varid, NULL, &vtype, &ndims, NULL, NULL);
+    ierr = PIOc_inq_var(ncid, varid, NULL, 0, &vtype, &ndims, NULL, NULL);
     if(ierr != PIO_NOERR)
     {
         LOG((1, "Unable to query ndims/type for var"));

--- a/src/flib/pio_nf.F90
+++ b/src/flib/pio_nf.F90
@@ -1219,16 +1219,17 @@ contains
     integer                                                 , intent(in) :: varid
     character(len=*)                                        , intent(out)    :: name
     interface
-       integer(C_INT) function PIOc_inq_varname(ncid        ,varid,name) &
+       integer(C_INT) function PIOc_inq_varname(ncid        ,varid,name,namelen) &
             bind(C                                          ,name="PIOc_inq_varname")
          use iso_c_binding
          integer(C_INT)                                     , value :: ncid
          integer(C_INT)                                     , value :: varid
          character(C_CHAR) :: name(*)
+         integer(C_INT)                                     , value :: namelen
        end function PIOc_inq_varname
     end interface
     name = C_NULL_CHAR
-    ierr = PIOc_inq_varname(ncid                            ,varid-1,name)
+    ierr = PIOc_inq_varname(ncid                            ,varid-1,name,len(name))
     call replace_c_null(name)
 
   end function inq_varname_id

--- a/tests/cunit/test_common.c
+++ b/tests/cunit/test_common.c
@@ -563,7 +563,7 @@ check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *nci
         return ERR_WRONG;
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         return ret;
     if (strcmp(varname, VAR_NAME_S1) || vartype != NC_INT || varndims != NDIM_S1 ||
         vardimids != 0 || varnatts != 0)
@@ -621,7 +621,7 @@ create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nc
     printf("%d defining variable %s\n", my_rank, VAR_NAME_S2);
     if ((ret = PIOc_def_var(ncid, FIRST_VAR_NAME_S2, NC_INT, NDIM_S2, &dimid, &varid)))
         return ret;
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
         return ret;
     if (strcmp(varname2, FIRST_VAR_NAME_S2))
         return ERR_WRONG;
@@ -799,14 +799,14 @@ check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *nci
         return ERR_WRONG;
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         return ERR_CHECK;
     if (strcmp(varname, VAR_NAME_S2) || vartype != NC_INT || varndims != NDIM_S2 ||
         vardimids != 0 || varnatts != 0)
         return ERR_WRONG;
 
     /* Check the other functions that get these values. */
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
         return ERR_CHECK;
     if (strcmp(varname2, VAR_NAME_S2))
         return ERR_WRONG;

--- a/tests/cunit/test_intercomm2.c
+++ b/tests/cunit/test_intercomm2.c
@@ -161,14 +161,14 @@ int check_file(int iosysid, int format, char *filename, int my_rank)
         ERR(ERR_WRONG);
 
     /* Check out the variable. */
-    if ((ret = PIOc_inq_var(ncid, 0, varname, &vartype, &varndims, &vardimids, &varnatts)))
+    if ((ret = PIOc_inq_var(ncid, 0, varname, NC_MAX_NAME + 1, &vartype, &varndims, &vardimids, &varnatts)))
         ERR(ret);
     if (strcmp(varname, VAR_NAME) || vartype != NC_INT || varndims != NDIM ||
         vardimids != 0 || varnatts != 0)
         ERR(ERR_WRONG);
 
     /* Check the other functions that get these values. */
-    if ((ret = PIOc_inq_varname(ncid, 0, varname2)))
+    if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
         ERR(ret);
     if (strcmp(varname2, VAR_NAME))
         ERR(ERR_WRONG);
@@ -421,7 +421,7 @@ int main(int argc, char **argv)
 		printf("%d test_intercomm2 defining variable %s\n", my_rank, VAR_NAME);
                 if ((ret = PIOc_def_var(ncid, FIRST_VAR_NAME, NC_INT, NDIM, &dimid, &varid)))
                     ERR(ret);
-                if ((ret = PIOc_inq_varname(ncid, 0, varname2)))
+                if ((ret = PIOc_inq_varname(ncid, 0, varname2, NC_MAX_NAME + 1)))
                     ERR(ret);
                 if (strcmp(varname2, FIRST_VAR_NAME))
                     ERR(ERR_WRONG);

--- a/tests/cunit/test_pioc.c
+++ b/tests/cunit/test_pioc.c
@@ -295,7 +295,7 @@ int check_var_name(int my_rank, int ncid, MPI_Comm test_comm)
         MPIERR(ret);
 
     memset(var_name, 0, sizeof(var_name));
-    if ((ret = PIOc_inq_varname(ncid, 0, var_name)))
+    if ((ret = PIOc_inq_varname(ncid, 0, var_name, PIO_MAX_NAME + 1)))
         return ret;
     printf("my_rank %d var name %s\n", my_rank, var_name);
 
@@ -823,13 +823,13 @@ int check_metadata(int ncid, int my_rank, int flavor)
     }
 
     /* Check the variable. */
-    if (PIOc_inq_var(ncid + 1, 0, name_in, &xtype_in, &ndims, dimid, &natts) != PIO_EBADID)
+    if (PIOc_inq_var(ncid + 1, 0, name_in, PIO_MAX_NAME + 1, &xtype_in, &ndims, dimid, &natts) != PIO_EBADID)
         return ERR_WRONG;
-    if (PIOc_inq_var(ncid, 45, name_in, &xtype_in, &ndims, dimid, &natts) != PIO_ENOTVAR)
+    if (PIOc_inq_var(ncid, 45, name_in, PIO_MAX_NAME + 1, &xtype_in, &ndims, dimid, &natts) != PIO_ENOTVAR)
         return ERR_WRONG;
-    if ((ret = PIOc_inq_var(ncid, 0, name_in, NULL, NULL, NULL, NULL)))
+    if ((ret = PIOc_inq_var(ncid, 0, name_in, PIO_MAX_NAME + 1, NULL, NULL, NULL, NULL)))
         return ret;
-    if ((ret = PIOc_inq_var(ncid, 0, name_in, &xtype_in, &ndims, dimid, &natts)))
+    if ((ret = PIOc_inq_var(ncid, 0, name_in, PIO_MAX_NAME + 1, &xtype_in, &ndims, dimid, &natts)))
         return ret;
     if (strcmp(name_in, VAR_NAME) || xtype_in != PIO_INT || ndims != NDIM ||
         dimid[0] != 0 || dimid[1] != 1 || dimid[2] != 2 || natts != 1)
@@ -1310,9 +1310,9 @@ int test_nc4(int iosysid, int num_flavors, int *flavor, int my_rank)
 
             /* Check that the inq_varname function works. */
             printf("%d Checking varname\n", my_rank);
-            if ((ret = PIOc_inq_varname(ncid, 0, NULL)))
+            if ((ret = PIOc_inq_varname(ncid, 0, NULL, 0)))
                 ERR(ret);
-            if ((ret = PIOc_inq_varname(ncid, 0, varname_in)))
+            if ((ret = PIOc_inq_varname(ncid, 0, varname_in, PIO_MAX_NAME)))
                 ERR(ret);
 
             /* Check that the inq_var_chunking function works. */
@@ -1423,7 +1423,7 @@ int check_scalar_var(int ncid, int varid, int flavor)
     int ret;
 
     /* Learn the var metadata. */
-    if ((ret = PIOc_inq_var(ncid, varid, var_name_in, &var_type_in, &ndims_in, NULL,
+    if ((ret = PIOc_inq_var(ncid, varid, var_name_in, PIO_MAX_NAME + 1, &var_type_in, &ndims_in, NULL,
                             &natts_in)))
         return ret;
 


### PR DESCRIPTION
Updating PIO2 C and Fortran interfaces related to inq_varname.

For master branch, there is a known buffer overflow caused by
strncpy() in PIOc_inq_var. Some ACME tests/cases have failed
due to that issue.

PIOc_inq_varname and PIOc_inq_var now need to know the size
of the user buffer, and use that information when copying variable
name to the buffer.

Fixes #56