### PR TITLE
Allow close+open instead of sync in fortran tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set (PIO_FILESYSTEM_HINTS IGNORE CACHE STRING "Filesystem hints (lustre or gpfs)
 option (PIO_ENABLE_TESTS  "Enable the testing builds"                           ON)
 option (PIO_ENABLE_LARGE_TESTS  "Enable large (file, processes) tests"         OFF)
 option (PIO_VALGRIND_CHECK  "Enable memory leak check using valgrind"           OFF)
+option (PIO_TEST_CLOSE_OPEN_FOR_SYNC  "PIO fortran tests will close+open for sync"  OFF)
 
 #==============================================================================
 #  BACKWARDS COMPATIBILITY

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -50,6 +50,10 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
   #        PRIVATE -mismatch_all)
 endif ()
 
+if (PIO_TEST_CLOSE_OPEN_FOR_SYNC)
+  add_definitions(-DPIO_TEST_CLOSE_OPEN_FOR_SYNC)
+endif()
+
 #==============================================================================
 #  DEFINE THE TARGETS AND TESTS
 #==============================================================================

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -128,6 +128,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_0dvar
   CHARACTER(len=1) :: pcval, gcval
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_scalar_var_put_val'
+  character(len=*), parameter :: PIO_CVAR_NAME = 'dummy_scalar_var_put_cval'
   integer :: num_iotypes
   integer :: i, ret
   
@@ -142,10 +144,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_0dvar
     PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
 
     ! Since file is just created no need to enter redef
-    ret = PIO_def_var(pio_file, 'dummy_scalar_var_put_val', PIO_TF_DATA_TYPE, pio_var)
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_var)
     PIO_TF_CHECK_ERR(ret, "Failed to define scalar var:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, 'dummy_scalar_var_put_cval', PIO_char, pio_cvar)
+    ret = PIO_def_var(pio_file, PIO_CVAR_NAME, PIO_char, pio_cvar)
     PIO_TF_CHECK_ERR(ret, "Failed to define scalar char var:" // trim(filename))
 
     ret = PIO_enddef(pio_file)
@@ -157,7 +159,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_0dvar
     ret = PIO_put_var(pio_file, pio_cvar, pcval);
     PIO_TF_CHECK_ERR(ret, "Failed to put scalar char var:" // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NAME, pio_cvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ret = PIO_get_var(pio_file, pio_var, gval);
     PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
@@ -191,6 +206,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar
   CHARACTER(len=DIM_LEN) :: pcval, gcval
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_var_put_val'
+  character(len=*), parameter :: PIO_CVAR_NAME = 'dummy_var_put_cval'
   integer :: num_iotypes
   integer :: i, ret
   
@@ -208,10 +225,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar
     ret = PIO_def_dim(pio_file, 'dummy_dim_put_val', DIM_LEN, pio_dim)
     PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, 'dummy_var_put_val', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, 'dummy_var_put_cval', PIO_char, (/pio_dim/), pio_cvar)
+    ret = PIO_def_var(pio_file, PIO_CVAR_NAME, PIO_char, (/pio_dim/), pio_cvar)
     PIO_TF_CHECK_ERR(ret, "Failed to define char var:" // trim(filename))
 
     ret = PIO_enddef(pio_file)
@@ -223,7 +240,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar
     ret = PIO_put_var(pio_file, pio_cvar, pcval);
     PIO_TF_CHECK_ERR(ret, "Failed to put char var:" // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NAME, pio_cvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ret = PIO_get_var(pio_file, pio_var, gval);
     PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
@@ -251,6 +281,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_slice
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_var_put_val'
   type(var_desc_t)  :: pio_var, pio_cvar
   integer :: pio_dim
   integer, parameter :: MAX_ROW_DIM_LEN = 100
@@ -284,7 +315,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_slice
     ret = PIO_def_dim(pio_file, 'dummy_dim_put_val', MAX_ROW_DIM_LEN, pio_dim)
     PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, 'dummy_var_put_val', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
     ret = PIO_enddef(pio_file)
@@ -293,7 +324,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_slice
     ret = PIO_put_var(pio_file, pio_var, start, count, pval(:,COL_WRITE_DIM));
     PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ret = PIO_get_var(pio_file, pio_var, gval);
     PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
@@ -315,6 +356,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_4parts
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_var_put_val'
   type(var_desc_t)  :: pio_var, pio_cvar
   integer :: pio_dim
   integer, parameter :: DIM_LEN = 16
@@ -341,7 +383,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_4parts
     ret = PIO_def_dim(pio_file, 'dummy_dim_put_val', DIM_LEN, pio_dim)
     PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, 'dummy_var_put_val', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
     ret = PIO_enddef(pio_file)
@@ -363,7 +405,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_4parts
     ret = PIO_put_var(pio_file, pio_var, start, count, pval(PART_LEN * 3 + 1 : DIM_LEN))
     PIO_TF_CHECK_ERR(ret, "Failed to put var (4th part):" // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     start = PART_LEN * 3 + 1
     ret = PIO_get_var(pio_file, pio_var, start, count, gval(PART_LEN * 3 + 1 : DIM_LEN))
@@ -399,6 +451,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_var
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_2DVAR_NAME = '2d_val'
+  character(len=*), parameter :: PIO_3DVAR_NAME = '3d_val'
+  character(len=*), parameter :: PIO_4DVAR_NAME = '4d_val'
   integer, parameter :: MAX_DIMS = 4
   integer, parameter :: MAX_ROWS = 10
   integer, parameter :: MAX_COLS = 10
@@ -443,15 +498,15 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_var
     ret = PIO_def_dim(pio_file, 'timesteps', MAX_TIMES, pio_dims(4))
     PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, '2d_val', PIO_TF_DATA_TYPE,&
+    ret = PIO_def_var(pio_file, PIO_2DVAR_NAME, PIO_TF_DATA_TYPE,&
               (/pio_dims(1),pio_dims(4)/), pio_2dvar)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, '3d_val', PIO_TF_DATA_TYPE,&
+    ret = PIO_def_var(pio_file, PIO_3DVAR_NAME, PIO_TF_DATA_TYPE,&
               (/pio_dims(1),pio_dims(2),pio_dims(4)/), pio_3dvar)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
-    ret = PIO_def_var(pio_file, '4d_val', PIO_TF_DATA_TYPE,&
+    ret = PIO_def_var(pio_file, PIO_4DVAR_NAME, PIO_TF_DATA_TYPE,&
               pio_dims, pio_4dvar)
     PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
 
@@ -536,7 +591,23 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_var
       PIO_TF_CHECK_ERR(ret, "Failed to put 4d var:" // trim(filename))
     end do
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_2DVAR_NAME, pio_2dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 2d var" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_3DVAR_NAME, pio_3dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 3d var" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_4DVAR_NAME, pio_4dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 4d var" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ret = PIO_get_var(pio_file, pio_2dvar, gval_2d)
     PIO_TF_CHECK_ERR(ret, "Failed to get 2d var:" // trim(filename))

--- a/tests/general/ncdf_simple_tests.F90.in
+++ b/tests/general/ncdf_simple_tests.F90.in
@@ -133,6 +133,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_data_conversion
   type(var_desc_t)  :: pio_var_int, pio_var_real, pio_var_double
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: data_fname = "pio_test_data_conversion.nc"
+  character(len=*), parameter :: PIO_VAR_INT_NAME = 'PIO_TF_test_var_int'
+  character(len=*), parameter :: PIO_VAR_REAL_NAME = 'PIO_TF_test_var_real'
+  character(len=*), parameter :: PIO_VAR_DBL_NAME = 'PIO_TF_test_var_dbl'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
   PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: wbuf, rbuf
@@ -159,13 +162,13 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_data_conversion
   ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
   PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(data_fname))
 
-  ierr = PIO_def_var(pio_file, 'PIO_TF_test_var_int', PIO_int, (/pio_dim/), pio_var_int)
+  ierr = PIO_def_var(pio_file, PIO_VAR_INT_NAME, PIO_int, (/pio_dim/), pio_var_int)
   PIO_TF_CHECK_ERR(ierr, "Failed to define a var of int type : " // trim(data_fname))
 
-  ierr = PIO_def_var(pio_file, 'PIO_TF_test_var_real', PIO_real, (/pio_dim/), pio_var_real)
+  ierr = PIO_def_var(pio_file, PIO_VAR_REAL_NAME, PIO_real, (/pio_dim/), pio_var_real)
   PIO_TF_CHECK_ERR(ierr, "Failed to define a var of real type : " // trim(data_fname))
 
-  ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_double, (/pio_dim/), pio_var_double)
+  ierr = PIO_def_var(pio_file, PIO_VAR_DBL_NAME, PIO_double, (/pio_dim/), pio_var_double)
   PIO_TF_CHECK_ERR(ierr, "Failed to define a var of double type : " // trim(data_fname))
 
   ierr = PIO_enddef(pio_file)
@@ -183,7 +186,23 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_data_conversion
   call PIO_write_darray(pio_file, pio_var_double, wiodesc, wbuf, ierr)
   PIO_TF_CHECK_ERR(ierr, "Failed to write darray on a var of double type : " // trim(data_fname))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+  call PIO_closefile(pio_file)
+
+  ierr = PIO_openfile(pio_tf_iosystem_, pio_file, tgv_iotype, data_fname, PIO_nowrite)
+  PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(data_fname))
+
+  ierr = PIO_inq_varid(pio_file, PIO_VAR_INT_NAME, pio_var_int)
+  PIO_TF_CHECK_ERR(ierr, "Cannot inq int var " // trim(data_fname))
+
+  ierr = PIO_inq_varid(pio_file, PIO_VAR_REAL_NAME, pio_var_real)
+  PIO_TF_CHECK_ERR(ierr, "Cannot inq real var " // trim(data_fname))
+
+  ierr = PIO_inq_varid(pio_file, PIO_VAR_DBL_NAME, pio_var_double)
+  PIO_TF_CHECK_ERR(ierr, "Cannot inq double var " // trim(data_fname))
+#else
   call PIO_syncfile(pio_file)
+#endif
 
   ! Read the int type variable back (data conversion might occur: int => real, int => double)
   rbuf = 0

--- a/tests/general/pio_buf_lim_tests.F90.in
+++ b/tests/general/pio_buf_lim_tests.F90.in
@@ -31,6 +31,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_buf_limit_zero
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: iodesc
   integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
   PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: wbuf, rbuf
@@ -62,7 +63,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_buf_limit_zero
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -74,7 +75,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_buf_limit_zero
     call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var: " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ierr)
@@ -110,6 +121,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
   integer(kind=pio_offset_kind) :: iobuf_sz
   integer :: type_sz
   type(var_desc_t)  :: pio_var1, pio_var2, pio_var3
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
+  character(len=*), parameter :: PIO_VAR3_NAME = 'PIO_TF_test_var3'
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
   type(io_desc_t) :: iodesc
@@ -146,13 +160,13 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var1 : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var2 : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var3', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
+    ierr = PIO_def_var(pio_file, PIO_VAR3_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var3 : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -167,7 +181,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     call PIO_write_darray(pio_file, pio_var1, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var1) : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
@@ -187,7 +211,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var2) : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
@@ -216,7 +253,23 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
     call PIO_write_darray(pio_file, pio_var3, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray(var3) : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)

--- a/tests/general/pio_decomp_fillval.F90.in
+++ b/tests/general/pio_decomp_fillval.F90.in
@@ -6,6 +6,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_explicit_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
   ! Compdof value to suggest that data point is a hole, this hole
@@ -55,7 +56,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_explicit_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -65,7 +66,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_explicit_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
@@ -92,6 +103,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_implicit_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(:), allocatable :: wcompdof
   integer :: wcompdof_sz
@@ -154,7 +166,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_implicit_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -164,7 +176,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_implicit_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
@@ -193,6 +215,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_explicit_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
   ! Compdof value to suggest that data point is a hole 
@@ -240,7 +263,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_explicit_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -250,7 +273,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_explicit_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
@@ -277,6 +310,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_implicit_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(:), allocatable :: rcompdof
   integer :: rcompdof_sz
@@ -330,7 +364,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_implicit_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -339,7 +373,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_implicit_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ! Read only part of the written data
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)

--- a/tests/general/pio_decomp_fillval2.F90.in
+++ b/tests/general/pio_decomp_fillval2.F90.in
@@ -6,6 +6,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
   type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(:), allocatable :: wcompdof, rcompdof, compdof_rel_disps
   ! Compdof value to suggest that data point is a hole, this hole
@@ -74,11 +76,11 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE,&
                         (/pio_dim/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE,&
                         (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
@@ -92,7 +94,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_exp_fval
     call PIO_write_darray(pio_file, pio_var2, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, riodesc, rbuf, ierr)
@@ -131,6 +146,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
   type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(:), allocatable :: wcompdof, rcompdof
   integer, dimension(:), allocatable :: rcompdof_rel_disps
@@ -211,11 +228,11 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE,&
                         (/pio_dim/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE,&
                         (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
@@ -229,7 +246,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_mreg_imp_fval
     call PIO_write_darray(pio_file, pio_var2, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, riodesc, rbuf, ierr)
@@ -271,6 +301,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_one_val
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
   ! Compdof value to suggest that data point is a hole, this hole
@@ -331,7 +362,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_one_val
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -341,7 +372,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_one_val
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
@@ -370,6 +411,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_odd_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(VEC_LOCAL_SZ) :: wcompdof, rcompdof, compdof_rel_disps
   ! Compdof value to suggest that data point is a hole, this hole
@@ -426,7 +468,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_odd_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -436,7 +478,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_odd_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)

--- a/tests/general/pio_decomp_frame_tests.F90.in
+++ b/tests/general/pio_decomp_frame_tests.F90.in
@@ -8,6 +8,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_2d_unlim_dim
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -65,7 +66,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_2d_unlim_dim
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(2))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -78,7 +79,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_2d_unlim_dim
       PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
     end do
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
@@ -209,6 +220,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -293,7 +305,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -306,7 +318,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_4d_col_decomp
       PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
     end do
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     do f=1,NFRAMES
       call PIO_setframe(pio_file, pio_var, f)
@@ -346,6 +368,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
   type(var_desc_t)  :: pio_var3d, pio_var4d
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_3DVAR_NAME = 'PIO_TF_test_3d_var'
+  character(len=*), parameter :: PIO_4DVAR_NAME = 'PIO_TF_test_4d_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -469,10 +493,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(4))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_3d_var', PIO_TF_DATA_TYPE, pio_dims(1:3), pio_var3d)
+    ierr = PIO_def_var(pio_file, PIO_3DVAR_NAME, PIO_TF_DATA_TYPE, pio_dims(1:3), pio_var3d)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a 3d var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_4d_var', PIO_TF_DATA_TYPE, pio_dims, pio_var4d)
+    ierr = PIO_def_var(pio_file, PIO_4DVAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var4d)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a 4d var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -487,7 +511,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_reuse_3d_decomp
       call PIO_write_darray(pio_file, pio_var4d, wr_iodesc, wbuf4d(:,:,:,f), ierr)
       PIO_TF_CHECK_ERR(ierr, "Failed to write 4d darray : " // trim(filename))
     end do
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_3DVAR_NAME, pio_var3d)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq 3d var : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_4DVAR_NAME, pio_var4d)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq 4d var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf4d = 0
     rbuf3d = 0

--- a/tests/general/pio_decomp_tests.F90.in
+++ b/tests/general/pio_decomp_tests.F90.in
@@ -79,6 +79,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
   type(var_desc_t)  :: pio_var1, pio_var2
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
   type(io_desc_t) :: iodesc
   integer, dimension(:), allocatable :: compdof, compdof_rel_disps
   integer :: compdof_rel_start
@@ -136,10 +138,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define first var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define second var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -153,7 +155,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_const_buf_sz
     call PIO_write_darray(pio_file, pio_var2, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write second darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, iodesc, rbuf, ierr)
@@ -184,6 +199,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
   type(var_desc_t)  :: pio_var1_file1, pio_var2_file1, pio_var1_file2
   type(file_desc_t) :: pio_file1, pio_file2
   character(len=PIO_TF_MAX_STR_LEN) :: filename1, filename2
+  character(len=*), parameter :: PIO_VAR1_FILE1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_FILE1_NAME = 'PIO_TF_test_var2'
+  character(len=*), parameter :: PIO_VAR1_FILE2_NAME = 'PIO_TF_test_var1'
   type(io_desc_t) :: iodesc
   integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
   PIO_TF_FC_DATA_TYPE, dimension(VEC_LOCAL_SZ) :: buf, rbuf
@@ -224,15 +242,15 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
     ierr = PIO_def_dim(pio_file2, 'PIO_TF_test_dim', dims(1), pio_dim_file2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename2))
 
-    ierr = PIO_def_var(pio_file1, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file1, PIO_VAR1_FILE1_NAME, PIO_TF_DATA_TYPE,&
                           (/pio_dim_file1/), pio_var1_file1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define first var : " // trim(filename1))
 
-    ierr = PIO_def_var(pio_file1, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file1, PIO_VAR2_FILE1_NAME, PIO_TF_DATA_TYPE,&
                           (/pio_dim_file1/), pio_var2_file1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define second var : " // trim(filename1))
 
-    ierr = PIO_def_var(pio_file2, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE,&
+    ierr = PIO_def_var(pio_file2, PIO_VAR1_FILE2_NAME, PIO_TF_DATA_TYPE,&
                           (/pio_dim_file2/), pio_var1_file2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define first var : " // trim(filename2))
 
@@ -253,7 +271,20 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
     call PIO_write_darray(pio_file2, pio_var1_file2, iodesc, buf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write first darray : " // trim(filename2))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file1)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file1, iotypes(i), filename1, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename1))
+
+    ierr = PIO_inq_varid(pio_file1, PIO_VAR1_FILE1_NAME, pio_var1_file1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 file1 :" // trim(filename1))
+
+    ierr = PIO_inq_varid(pio_file1, PIO_VAR2_FILE1_NAME, pio_var2_file1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 file1 :" // trim(filename1))
+#else
     call PIO_syncfile(pio_file1)
+#endif
     rbuf = 0
     call PIO_read_darray(pio_file1, pio_var1_file1, iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read first darray : " // trim(filename1))
@@ -266,7 +297,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_1d_reuse_decomp
 
     PIO_TF_CHECK_VAL((rbuf, buf), "Got wrong val")
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file2)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file2, iotypes(i), filename2, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename2))
+
+    ierr = PIO_inq_varid(pio_file2, PIO_VAR1_FILE2_NAME, pio_var1_file2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 file2 :" // trim(filename2))
+#else
     call PIO_syncfile(pio_file2)
+#endif
     rbuf = 0
     call PIO_read_darray(pio_file2, pio_var1_file2, iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read first darray : " // trim(filename2))

--- a/tests/general/pio_decomp_tests_1d.F90.in
+++ b/tests/general/pio_decomp_tests_1d.F90.in
@@ -211,6 +211,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
@@ -269,7 +270,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
         ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
         PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-        ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+        ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
         PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
         ierr = PIO_enddef(pio_file)
@@ -279,7 +280,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
         call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
         PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+        call PIO_closefile(pio_file)
+
+        ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+        PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+        ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+        PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
         call PIO_syncfile(pio_file)
+#endif
 
         rbuf = 0
         call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
@@ -323,6 +334,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_mreg_1d_bc
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(:), allocatable :: start, count
@@ -374,7 +386,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_mreg_1d_bc
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -384,7 +396,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_mreg_1d_bc
     call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ierr)
@@ -413,6 +435,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
@@ -451,7 +474,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -461,7 +484,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_bc_with_holes
     call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, wr_iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
@@ -492,6 +525,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_rev
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
@@ -530,7 +564,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_rev
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -540,7 +574,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_1d_rev
     call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, wr_iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))

--- a/tests/general/pio_decomp_tests_2d.F90.in
+++ b/tests/general/pio_decomp_tests_2d.F90.in
@@ -161,6 +161,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_col_decomp
   type(file_desc_t) :: pio_file
   integer, parameter :: NDIMS = 2
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -225,7 +226,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_col_decomp
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -235,7 +236,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_col_decomp
     call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
@@ -268,6 +279,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_row_decomp
   type(file_desc_t) :: pio_file
   integer, parameter :: NDIMS = 2
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -332,7 +344,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_row_decomp
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_col', dims(2), pio_dims(2))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -342,7 +354,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_2d_row_decomp
     call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))

--- a/tests/general/pio_decomp_tests_3d.F90.in
+++ b/tests/general/pio_decomp_tests_3d.F90.in
@@ -99,6 +99,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_3d_col_decomp
   type(file_desc_t) :: pio_file
   integer, parameter :: NDIMS = 3
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(NDIMS) :: start, count
@@ -174,7 +175,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_3d_col_decomp
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_hgt', dims(3), pio_dims(3))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -184,7 +185,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_read_3d_col_decomp
     call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))

--- a/tests/general/pio_iodesc_tests.F90.in
+++ b/tests/general/pio_iodesc_tests.F90.in
@@ -101,6 +101,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_2d_two_iodescs
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc, wr_iodesc_shifted
   integer, dimension(:), allocatable :: compdof
   integer, dimension(:), allocatable :: start, count
@@ -215,7 +216,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_2d_two_iodescs
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_time', pio_unlimited, pio_dims(2))
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, pio_dims, pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, pio_dims, pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -240,7 +241,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_2d_two_iodescs
       PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
     end do
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var :" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     ! Read data - with no shift
     do f=1,NFRAMES

--- a/tests/general/pio_large_file_tests.F90.in
+++ b/tests/general/pio_large_file_tests.F90.in
@@ -108,6 +108,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_large_1d_bc
   type(var_desc_t)  :: pio_var, pio_last_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(1) :: start, count
@@ -179,7 +180,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_large_1d_bc
       ierr = PIO_def_dim(pio_file, 'PIO_TF_test_last_var_dim', last_var_dims(1), pio_last_var_dim)
       PIO_TF_CHECK_ERR(ierr, "Failed to define a dim (last var) : " // trim(filename))
 
-      ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+      ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
       PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
       ! The last var is special, with relaxed constraints - we just define it and ignore it
@@ -194,7 +195,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_large_1d_bc
       call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
       PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+      call PIO_closefile(pio_file)
+
+      ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+      PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+      ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+      PIO_TF_CHECK_ERR(ierr, "Could not inq var :" // trim(filename))
+#else
       call PIO_syncfile(pio_file)
+#endif
 
       rbuf = 0
       call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
@@ -315,6 +326,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_large_1d_fval
   type(var_desc_t)  :: pio_var
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
   type(io_desc_t) :: wiodesc, riodesc
   integer, dimension(:), allocatable :: wcompdof
   integer :: wcompdof_sz
@@ -377,7 +389,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_large_1d_fval
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -387,7 +399,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_write_large_1d_fval
     call PIO_write_darray(pio_file, pio_var, wiodesc, wbuf, ierr, BUF_FILLVAL)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var :" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, riodesc, rbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))

--- a/tests/general/pio_rearr.F90.in
+++ b/tests/general/pio_rearr.F90.in
@@ -108,7 +108,17 @@ SUBROUTINE open_and_check_rdwr(comm, iosys, iotype, pio_file, fname, ret)
     call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ret)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to write darray: " // fname)
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(iosys, pio_file, iotype, fname, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Could not reopen file " // trim(fname))
+
+    ret = PIO_inq_varid(pio_file, var_name, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Could not inq var :" // trim(fname))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ret)
     PIO_TF_CHECK_ERR(ret, comm, "Failed to read darray: " // fname)

--- a/tests/general/pio_rearr_opts.F90.in
+++ b/tests/general/pio_rearr_opts.F90.in
@@ -442,7 +442,15 @@ PIO_TF_AUTO_TEST_SUB_BEGIN write_with_rearr_opts
                       call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ret)
                       PIO_TF_CHECK_ERR(ret, dup_comm, "Writing var failed fname="//trim(tgv_fname))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+                      call PIO_closefile(pio_file)
+
+                      call open_file_and_get_var(dup_iosys, pio_file, iotypes(i),&
+                              pio_var, dims, ret)
+                      PIO_TF_CHECK_ERR(ret, dup_comm, "Reopening file/decomp/var reqd for test failed :" // trim(tgv_fname))
+#else
                       call PIO_syncfile(pio_file)
+#endif
 
                       call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ret)
                       PIO_TF_CHECK_ERR(ret, dup_comm, "Reading var failed fname="//trim(tgv_fname))

--- a/tests/general/pio_rearr_opts2.F90.in
+++ b/tests/general/pio_rearr_opts2.F90.in
@@ -385,7 +385,14 @@ PIO_TF_AUTO_TEST_SUB_BEGIN set_rearr_opts_and_write
                     call PIO_write_darray(pio_file, pio_var, iodesc, wbuf, ret)
                     PIO_TF_CHECK_ERR(ret, "Writing var failed fname="//trim(tgv_fname))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+                    call PIO_closefile(pio_file)
+
+                    call open_file_and_get_var(pio_file, iotypes(i), pio_var, ret)
+                    PIO_TF_CHECK_ERR(ret, "Reopening file/decomp/var reqd for test failed :" // trim(tgv_fname))
+#else
                     call PIO_syncfile(pio_file)
+#endif
 
                     call PIO_read_darray(pio_file, pio_var, iodesc, rbuf, ret)
                     PIO_TF_CHECK_ERR(ret, "Reading var failed fname="//trim(tgv_fname))

--- a/tests/general/pio_sync_tests.F90.in
+++ b/tests/general/pio_sync_tests.F90.in
@@ -115,6 +115,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_wr_rd_1d_bc
   type(var_desc_t)  :: pio_var1, pio_var2, pio_var3
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
+  character(len=*), parameter :: PIO_VAR3_NAME = 'PIO_TF_test_var3'
   type(io_desc_t) :: wr_iodesc, rd_iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(:), allocatable :: start, count
@@ -173,13 +176,13 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_wr_rd_1d_bc
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var3', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
+    ierr = PIO_def_var(pio_file, PIO_VAR3_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var3)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -195,7 +198,23 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_wr_rd_1d_bc
     call PIO_write_darray(pio_file, pio_var3, wr_iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 :" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf = 0
     call PIO_read_darray(pio_file, pio_var1, rd_iodesc, rbuf, ierr)
@@ -260,6 +279,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_mreg_wr_rd_1d_bc
   type(var_desc_t)  :: pio_var1, pio_var2, pio_var3, pio_var4
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1_mreg'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2'
+  character(len=*), parameter :: PIO_VAR3_NAME = 'PIO_TF_test_var3_mreg'
+  character(len=*), parameter :: PIO_VAR4_NAME = 'PIO_TF_test_var4'
   type(io_desc_t) :: iodesc_mreg, iodesc
   integer, dimension(:), allocatable :: compdof
   integer, dimension(:), allocatable :: start, count
@@ -336,16 +359,16 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_mreg_wr_rd_1d_bc
     ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_mreg', dims_mreg(1), pio_dim_mreg)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a dim (mreg) : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var1_mreg', PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var1)
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var1)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var1) : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var2', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var2) : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var3_mreg', PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var3)
+    ierr = PIO_def_var(pio_file, PIO_VAR3_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mreg/), pio_var3)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var3) : " // trim(filename))
 
-    ierr = PIO_def_var(pio_file, 'PIO_TF_test_var4', PIO_TF_DATA_TYPE, (/pio_dim/), pio_var4)
+    ierr = PIO_def_var(pio_file, PIO_VAR4_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var4)
     PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var4) : " // trim(filename))
 
     ierr = PIO_enddef(pio_file)
@@ -364,7 +387,26 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_mvar_mreg_wr_rd_1d_bc
     call PIO_write_darray(pio_file, pio_var4, iodesc, wbuf, ierr)
     PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var4) : " // trim(filename))
 
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR4_NAME, pio_var4)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var4 :" // trim(filename))
+#else
     call PIO_syncfile(pio_file)
+#endif
 
     rbuf_mreg = 0
     call PIO_read_darray(pio_file, pio_var1, iodesc_mreg, rbuf_mreg, ierr)


### PR DESCRIPTION
Instead of syncing data to a file using PIO_syncfile(), the
fortran tests can optionally close and reopen the file.

The user can enable this by using the option,
"-DPIO_TEST_CLOSE_OPEN_FOR_SYNC:BOOL=ON" 
when configuring PIO.

Fixes #67