### PR TITLE
Avoid logging msgs to stdout

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -266,17 +266,19 @@ void pio_log(int severity, const char *fmt, ...)
     rem_len = MAX_LOG_MSG - strlen(msg);
     strncpy(ptr, "\n\0", (rem_len > 0) ? rem_len : 0);
 
-    /* Send message to stdout. */
-    fprintf(stdout, "%s", msg);
-
     /* Send message to log file. */
     if (LOG_FILE)
+    {
         fprintf(LOG_FILE, "%s", msg);
-
-    /* Ensure an immediate flush of stdout. */
-    fflush(stdout);
-    if (LOG_FILE)
         fflush(LOG_FILE);
+    }
+    else
+    {
+        /* Send message to stdout. */
+        fprintf(stdout, "%s", msg);
+        /* Ensure an immediate flush of stdout. */
+        fflush(stdout);
+    }
 }
 #endif /* PIO_ENABLE_LOGGING */
 


### PR DESCRIPTION
If a log file is available write out log messages to the log file
and avoid duplicating the log messages in stdout.

Fixes #71