### PR TITLE
Add tests for write+read with data having multiple regions

### DIFF
--- a/tests/general/pio_iodesc_tests.F90.in
+++ b/tests/general/pio_iodesc_tests.F90.in
@@ -78,6 +78,97 @@ SUBROUTINE get_1d_bc_shift_decomp_info(rank, sz, dims, start, count, nlshift)
 
 END SUBROUTINE
 
+! Get a block cyclic decomposition with multiple regions to write
+! from a single proc
+! # All procs have VEC_LOCAL_SZ elements starting at offset
+!   (sz * VEC_LOCAL_SZ) * iregion + VEC_LOCAL_SZ * rank + 1
+!   where iregion  is the current region,
+!         iregion = 0 => first region
+!         iregion = 1 => second region and so on
+! e.g. For VEC_LOCAL_SZ = 2, NUM_REGIONS=2
+! e.g. 1)    [1,2,7,8] [3,4,9,10] [5,6,11,12]
+SUBROUTINE get_1d_bc_mureg_info(rank, sz, dims, start, count)
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer, parameter :: NUM_REGIONS = 3
+  integer, intent(in) :: rank
+  integer, intent(in) :: sz
+  integer, dimension(1), intent(out) :: dims
+  integer, dimension(:), allocatable, intent(out) :: start
+  integer, dimension(:), allocatable, intent(out) :: count
+  integer :: i
+
+  dims(1) = sz * VEC_LOCAL_SZ * NUM_REGIONS
+  allocate(start(NUM_REGIONS))
+  allocate(count(NUM_REGIONS))
+
+  do i=1,NUM_REGIONS
+    count(i) = VEC_LOCAL_SZ
+    start(i) = rank * VEC_LOCAL_SZ + (i-1) * (sz * VEC_LOCAL_SZ) + 1
+  end do
+
+END SUBROUTINE get_1d_bc_mureg_info
+
+! Get a block cyclic decomposition with multiple regions to write
+! from a single proc, the number of regions written out by odd
+! and even procs are different (not uniform).
+! # All procs write regions of size VEC_LOCAL_SZ elements
+! # Odd procs write NUM_REGIONS_ODD and even procs write
+!   NUM_REGIONS_EVEN number of regions
+! e.g. For VEC_LOCAL_SZ = 2, NUM_REGIONS_ODD=2, NUM_REGIONS_EVEN=1
+! e.g. 1)    [1,2] [3,4,9,10] [5,6] [7,8,11,12]
+SUBROUTINE get_1d_bc_mnureg_info(rank, sz, dims, start, count)
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  integer, parameter :: NUM_REGIONS_ODD = 3
+  integer, parameter :: NUM_REGIONS_EVEN = 2
+  integer, intent(in) :: rank
+  integer, intent(in) :: sz
+  integer, dimension(1), intent(out) :: dims
+  integer, dimension(:), allocatable, intent(out) :: start
+  integer, dimension(:), allocatable, intent(out) :: count
+
+  integer :: num_regions, num_odd_procs, num_even_procs
+  integer :: num_odd_procs_bfr_rank, num_even_procs_bfr_rank
+  integer :: i, gcount
+  logical :: is_even
+
+  is_even = .false.
+  if(mod(rank, 2) == 0) then
+    is_even = .true.
+  end if
+  num_odd_procs = sz / 2
+  num_even_procs = sz - num_odd_procs
+  num_odd_procs_bfr_rank = rank/2
+  num_even_procs_bfr_rank = (rank+1)/2
+
+  if(is_even) then
+    num_regions = NUM_REGIONS_EVEN
+  else
+    num_regions = NUM_REGIONS_ODD
+  end if
+
+  dims(1) = num_odd_procs * VEC_LOCAL_SZ * NUM_REGIONS_ODD +&
+            num_even_procs * VEC_LOCAL_SZ * NUM_REGIONS_EVEN
+
+  allocate(start(num_regions))
+  allocate(count(num_regions))
+
+  ! The number of values already written out globally
+  gcount = 0
+  do i=1,num_regions
+    count(i) = VEC_LOCAL_SZ
+    start(i) = gcount + 1
+    if(i <= NUM_REGIONS_ODD) then
+      start(i) = start(i) + num_odd_procs_bfr_rank * VEC_LOCAL_SZ
+      gcount = gcount + num_odd_procs * VEC_LOCAL_SZ
+    endif
+    if(i <= NUM_REGIONS_EVEN) then
+      start(i) = start(i) + num_even_procs_bfr_rank * VEC_LOCAL_SZ
+      gcount = gcount + num_even_procs * VEC_LOCAL_SZ
+    endif
+  end do
+
+END SUBROUTINE get_1d_bc_mnureg_info
+
 ! Write multiple frames of data, even frames with no shift - evenly
 ! divided across all procs, and odd frames with data evenly divided
 ! across all procs but with a global cyclic left shift
@@ -282,3 +373,261 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_2d_two_iodescs
   deallocate(wbuf)
   deallocate(wbuf_shifted)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_2d_two_iodescs
+
+! Write two variables with multiple contiguous regions of data
+! The regions are uniform (same number of regions) across all
+! procs
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_mureg_wr_rd_1d_bc
+  implicit none
+  interface
+    subroutine get_1d_bc_mureg_info(rank, sz, dims, start, count)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+    end subroutine get_1d_bc_mureg_info
+  end interface
+  type(var_desc_t)  :: pio_var1, pio_var2
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1_mureg'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2_mureg'
+  type(io_desc_t) :: iodesc_mureg
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: start, count
+  integer :: total_count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf_mureg, wbuf_mureg
+  integer, dimension(1) :: dims_mureg
+  integer :: pio_dim_mureg
+  integer :: i, j, idx, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  call get_1d_bc_mureg_info(pio_tf_world_rank_, pio_tf_world_sz_,&
+         dims_mureg, start, count)
+  total_count = 0
+  do i=1,size(count)
+    total_count = total_count + count(i)
+  end do
+  allocate(wbuf_mureg(total_count))
+  allocate(rbuf_mureg(total_count))
+  allocate(compdof(total_count))
+  do i=1,size(count)
+    do j=1,count(i)
+      idx = (i-1)*count(i) + j
+      compdof(idx) = start(i) + j - 1
+      wbuf_mureg(idx) = compdof(idx)
+      rbuf_mureg(idx) = compdof(idx)
+    end do
+  end do
+  if(allocated(start)) then
+    deallocate(start)
+  end if
+  if(allocated(count)) then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims_mureg, compdof, iodesc_mureg)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_mureg', dims_mureg(1), pio_dim_mureg)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim (mureg) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mureg/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var1) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mureg/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var2) : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variables out
+    call PIO_write_darray(pio_file, pio_var1, iodesc_mureg, wbuf_mureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var1) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, iodesc_mureg, wbuf_mureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var2) : " // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 :" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    rbuf_mureg = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc_mureg, rbuf_mureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var1): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mureg, wbuf_mureg), "Got wrong val (var1)")
+
+    rbuf_mureg = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc_mureg, rbuf_mureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var2): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mureg, wbuf_mureg), "Got wrong val (var2)")
+
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc_mureg)
+  deallocate(rbuf_mureg)
+  deallocate(wbuf_mureg)
+PIO_TF_AUTO_TEST_SUB_END nc_mureg_wr_rd_1d_bc
+
+! Write two variables with multiple contiguous regions of data
+! The regions are non-uniform (Odd and even procs write out different
+! number of regions)
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_mnureg_wr_rd_1d_bc
+  implicit none
+  interface
+    subroutine get_1d_bc_mnureg_info(rank, sz, dims, start, count)
+      integer, intent(in) :: rank
+      integer, intent(in) :: sz
+      integer, dimension(1), intent(out) :: dims
+      integer, dimension(:), allocatable, intent(out) :: start
+      integer, dimension(:), allocatable, intent(out) :: count
+    end subroutine get_1d_bc_mnureg_info
+  end interface
+  type(var_desc_t)  :: pio_var1, pio_var2
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR1_NAME = 'PIO_TF_test_var1_mnureg'
+  character(len=*), parameter :: PIO_VAR2_NAME = 'PIO_TF_test_var2_mnureg'
+  type(io_desc_t) :: iodesc_mnureg
+  integer, dimension(:), allocatable :: compdof
+  integer, dimension(:), allocatable :: start, count
+  integer :: total_count
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf_mnureg, wbuf_mnureg
+  integer, dimension(1) :: dims_mnureg
+  integer :: pio_dim_mnureg
+  integer :: i, j, idx, ierr, lsz
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  call get_1d_bc_mnureg_info(pio_tf_world_rank_, pio_tf_world_sz_,&
+         dims_mnureg, start, count)
+  total_count = 0
+  do i=1,size(count)
+    total_count = total_count + count(i)
+  end do
+  allocate(wbuf_mnureg(total_count))
+  allocate(rbuf_mnureg(total_count))
+  allocate(compdof(total_count))
+  do i=1,size(count)
+    do j=1,count(i)
+      idx = (i-1)*count(i) + j
+      compdof(idx) = start(i) + j - 1
+      wbuf_mnureg(idx) = compdof(idx)
+      rbuf_mnureg(idx) = compdof(idx)
+    end do
+  end do
+  if(allocated(start)) then
+    deallocate(start)
+  end if
+  if(allocated(count)) then
+    deallocate(count)
+  end if
+
+  call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims_mnureg, compdof, iodesc_mnureg)
+  deallocate(compdof)
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_decomp_simple_tests.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim_mnureg', dims_mnureg(1), pio_dim_mnureg)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim (mnureg) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR1_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mnureg/), pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var1) : " // trim(filename))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR2_NAME, PIO_TF_DATA_TYPE, (/pio_dim_mnureg/), pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var (var2) : " // trim(filename))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+    ! Write the variables out
+    call PIO_write_darray(pio_file, pio_var1, iodesc_mnureg, wbuf_mnureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var1) : " // trim(filename))
+
+    call PIO_write_darray(pio_file, pio_var2, iodesc_mnureg, wbuf_mnureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to write darray (var2) : " // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR1_NAME, pio_var1)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var1 :" // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var2 :" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    rbuf_mnureg = 0
+    call PIO_read_darray(pio_file, pio_var1, iodesc_mnureg, rbuf_mnureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var1): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mnureg, wbuf_mnureg), "Got wrong val (var1)")
+
+    rbuf_mnureg = 0
+    call PIO_read_darray(pio_file, pio_var2, iodesc_mnureg, rbuf_mnureg, ierr)
+    PIO_TF_CHECK_ERR(ierr, "Failed to read darray (var2): " // trim(filename))
+
+    PIO_TF_CHECK_VAL((rbuf_mnureg, wbuf_mnureg), "Got wrong val (var2)")
+
+    call PIO_closefile(pio_file)
+
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+  call PIO_freedecomp(pio_tf_iosystem_, iodesc_mnureg)
+  deallocate(rbuf_mnureg)
+  deallocate(wbuf_mnureg)
+PIO_TF_AUTO_TEST_SUB_END nc_mnureg_wr_rd_1d_bc


### PR DESCRIPTION
Adding two tests writing/reading variables with multiple
contiguous regions.

The two tests differ in the number of regions written out
from a single process.