### PR TITLE
Descriptive log mesg when switching iotypes - pio2

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2172,7 +2172,13 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
 
                 /* open netcdf file serially on main task */
                 if (ios->io_rank == 0)
+                {
                     ierr = nc_open(filename, file->mode, &file->fh);
+                    if(ierr == NC_NOERR)
+                    {
+                        printf("PIO: Opening file (%s) with iotype=%d failed. Switching iotype to PIO_IOTYPE_NETCDF\n", filename, *iotype);
+                    }
+                }
                 else
                     file->do_io = 0;
             }


### PR DESCRIPTION
More descriptive log message when switching user-specified
iotype to another iotype.

See Issue #63