### PR TITLE
Only use bget for caching user data

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -667,10 +667,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     {
         /* Allocate a buffer. */
         LOG((3, "allocating multi-buffer"));
-        if (!(wmb->next = bget((bufsize)sizeof(wmulti_buffer))))
+        if (!(wmb->next = calloc(1, sizeof(wmulti_buffer))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
-        /* if (!(wmb->next = calloc(1, sizeof(wmulti_buffer)))) */
-        /*     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__); */
         LOG((3, "allocated multi-buffer"));
 
         /* Set pointer to newly allocated buffer and initialize.*/

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -786,14 +786,14 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 
     /* vid is an array of variable ids in the wmb list, grow the list
      * and add the new entry. */
-    if (!(wmb->vid = bgetr(wmb->vid, sizeof(int) * (1 + wmb->num_arrays))))
+    if (!(wmb->vid = realloc(wmb->vid, sizeof(int) * (1 + wmb->num_arrays))))
         return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* wmb->frame is the record number, we assume that the variables
      * in the wmb list may not all have the same unlimited dimension
      * value although they usually do. */
     if (vdesc->record >= 0)
-        if (!(wmb->frame = bgetr(wmb->frame, sizeof(int) * (1 + wmb->num_arrays))))
+        if (!(wmb->frame = realloc(wmb->frame, sizeof(int) * (1 + wmb->num_arrays))))
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__);
 
     /* If we need a fill value, get it. If we are using the subset

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -1715,7 +1715,7 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
         wmb->num_arrays = 0;
 
         /* Release the list of variable IDs. */
-        brel(wmb->vid);
+        free(wmb->vid);
         wmb->vid = NULL;
 
         /* Release the data memory. */
@@ -1729,7 +1729,7 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
 
         /* Release the record number. */
         if (wmb->frame)
-            brel(wmb->frame);
+            free(wmb->frame);
         wmb->frame = NULL;
 
         if (ret)

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -424,7 +424,7 @@ int PIOc_sync(int ncid)
                 }
                 else
                 {
-                    brel(twmb);
+                    free(twmb);
                 }
             }
         }


### PR DESCRIPTION
Making sure that we use bget only for caching
user data written out using PIO.

For regular data structures in the code we use 
malloc/calloc/realloc/free to manage memory.

Fixes #89 